### PR TITLE
Fixing some issues when exporting

### DIFF
--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -715,6 +715,12 @@ class __PmxExporter:
             self.__model.name_e = root.mmd_root.name_e
 
         self.__model.comment = 'exported by mmd_tools'
+        #We retrieve the comment from the Blender internal texts if present
+        if 'text_'+self.__model.name in bpy.data.texts.keys():
+            self.__model.comment = bpy.data.texts['text_'+self.__model.name].as_string().replace('\n', '\r\n')
+            
+        if 'text_'+self.__model.name+'_e' in bpy.data.texts.keys():
+            self.__model.comment_e = bpy.data.texts['text_'+self.__model.name+'_e'].as_string().replace('\n', '\r\n')
 
         meshes = args.get('meshes', [])
         self.__armature = args.get('armature', None)

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -73,6 +73,15 @@ class PMXImporter:
         """
         pmxModel = self.__model
         self.__rig = mmd_model.Model.create(pmxModel.name, pmxModel.name_e, self.__scale)
+        
+        #We will use Blender internal texts to store the model comment/description
+        if pmxModel.comment is not None and pmxModel.comment != '':
+            desc = bpy.data.texts.new('text_'+pmxModel.name)        
+            desc.write(pmxModel.comment.replace('\r\n', '\n'))
+        
+        if pmxModel.comment_e is not None and pmxModel.comment_e != '':
+            desc = bpy.data.texts.new('text_'+pmxModel.name+'_e')
+            desc.write(pmxModel.comment_e.replace('\r\n', '\n'))
 
         mesh = bpy.data.meshes.new(name=pmxModel.name)
         self.__meshObj = bpy.data.objects.new(name=pmxModel.name+'_mesh', object_data=mesh)


### PR DESCRIPTION
If a mesh had internal textures the addon crashed because the `image` attribute is not present. A safety check was added to prevent this.

Also if the model didn't had shape keys or uv textures it failed because it is assumed to have them. In case any of the two elements are not present they are created automatically.
