### PR TITLE
Adding Multi-Mesh support for Morphs(WIP)

### DIFF
--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import bpy
-from bpy.types import Operator
 import mathutils
 
 from mmd_tools import bpyutils
@@ -394,6 +393,15 @@ class Model:
     def firstMesh(self):
         for i in self.meshes():
             return i
+        return None
+
+    def findMesh(self, mesh_name):
+        """
+        Helper method to find a mesh by name
+        """
+        for mesh in self.meshes():
+            if mesh.name == mesh_name or mesh.data.name == mesh_name:
+                return mesh
         return None
 
     def rigidBodies(self):

--- a/mmd_tools/core/morph.py
+++ b/mmd_tools/core/morph.py
@@ -1,0 +1,27 @@
+
+
+class FnMorph(object):
+    
+    def __init__(self, morph, model):
+        self.__morph = morph
+        self.__rig = model
+    
+    def update_mat_related_mesh(self, new_mesh=None):
+        for offset in self.__morph.data:
+            # Use the new_mesh if provided  
+            meshObj = new_mesh          
+            if new_mesh is None:
+                # Try to find the mesh by material name
+                meshObj = self.__rig.findMesh(offset.material)
+            
+            if meshObj is None:
+                # Given this point we need to loop through all the meshes
+                for mesh in self.__rig.meshes():
+                    if mesh.data.materials.find(offset.material) <= 0:
+                        meshObj = mesh
+                        break
+
+            # Finally update the reference
+            if meshObj is not None:
+                offset.related_mesh = meshObj.data.name
+            

--- a/mmd_tools/core/morph.py
+++ b/mmd_tools/core/morph.py
@@ -17,7 +17,7 @@ class FnMorph(object):
             if meshObj is None:
                 # Given this point we need to loop through all the meshes
                 for mesh in self.__rig.meshes():
-                    if mesh.data.materials.find(offset.material) <= 0:
+                    if mesh.data.materials.find(offset.material) >= 0:
                         meshObj = mesh
                         break
 

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -466,6 +466,7 @@ class PMXImporter:
             mat_morph.category = categories.get(morph.category, 'OTHER')
             for morph_data in morph.offsets:
                 data = mat_morph.data.add()
+                data.related_mesh = self.__meshObj.data.name
                 data.material = self.__materialTable[morph_data.index].name
                 data.offset_type = ['MULT', 'ADD'][morph_data.offset_type]
                 data.diffuse_color = morph_data.diffuse_offset

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -239,12 +239,14 @@ class ExportPmx(Operator, ExportHelper):
             logger.addHandler(handler)
 
         root = mmd_model.Model.findRoot(context.active_object)
-        if root.mmd_root.editing_morph:
+        if root.mmd_root.editing_morphs > 0:
             # We have two options here: 
             # 1- report it to the user
             # 2- clear the active morphs (user will loose any changes to temp materials and UV) 
-            self.report({ 'ERROR' }, "You are editing a morph, apply or clear it before proceed")
-            return { 'CANCELLED' }
+            bpy.ops.mmd_tools.clear_temp_materials()
+            bpy.ops.mmd_tools.clear_uv_morph_view()        
+            self.report({ 'WARNING' }, "Active editing morphs were cleared")
+            # return { 'CANCELLED' }
         rig = mmd_model.Model(root)
         rig.clean()
         try:

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -9,6 +9,7 @@ from bpy.types import Operator
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 
 from mmd_tools import auto_scene_setup
+from mmd_tools.utils import selectAObject
 
 import mmd_tools.core.pmd.importer as pmd_importer
 import mmd_tools.core.pmx.importer as pmx_importer
@@ -249,6 +250,16 @@ class ExportPmx(Operator, ExportHelper):
             # return { 'CANCELLED' }
         rig = mmd_model.Model(root)
         rig.clean()
+        # Clear the pose before exporting
+        if rig.armature():
+            prev_show = root.mmd_root.show_armature
+            root.mmd_root.show_armature = True
+            selectAObject(rig.armature())
+            bpy.ops.object.mode_set(mode='POSE')
+            bpy.ops.pose.select_all(action='SELECT')
+            bpy.ops.pose.transforms_clear()
+            bpy.ops.object.mode_set(mode='OBJECT')
+            root.mmd_root.show_armature = prev_show
         try:
             pmx_exporter.export(
                 filepath=self.filepath,

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -239,6 +239,12 @@ class ExportPmx(Operator, ExportHelper):
             logger.addHandler(handler)
 
         root = mmd_model.Model.findRoot(context.active_object)
+        if root.mmd_root.editing_morph:
+            # We have two options here: 
+            # 1- report it to the user
+            # 2- clear the active morphs (user will loose any changes to temp materials and UV) 
+            self.report({ 'ERROR' }, "You are editing a morph, apply or clear it before proceed")
+            return { 'CANCELLED' }
         rig = mmd_model.Model(root)
         rig.clean()
         try:

--- a/mmd_tools/operators/misc.py
+++ b/mmd_tools/operators/misc.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
+import bpy
 from bpy.types import Operator
 
 from mmd_tools import utils
+from mmd_tools.core import model as mmd_model
 
 
 class SeparateByMaterials(Operator):
@@ -19,3 +21,30 @@ class SeparateByMaterials(Operator):
     def execute(self, context):
         utils.separateByMaterials(context.active_object)
         return {'FINISHED'}
+
+class JoinMeshes(Operator):
+    bl_idname = 'mmd_tool.join_meshes'
+    bl_label = 'Join Meshes'
+    bl_description = 'Join the Model meshes into a single one'
+    bl_options = {'PRESET'}
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.active_object
+        return obj and obj.type == 'MESH'
+
+    def execute(self, context):
+        obj = context.active_object
+        root = mmd_model.Model.findRoot(obj)
+        if root is None:
+            self.report({ 'ERROR' }, 'Select a MMD model') 
+            return { 'CANCELLED' } 
+        # Find all the meshes in mmd_root and join them          
+        rig = mmd_model.Model(root)
+        bpy.ops.object.select_all(action='DESELECT')
+        for mesh in rig.meshes():
+            mesh.select = True
+        bpy.context.scene.objects.active = rig.firstMesh()        
+        bpy.ops.object.join()
+        return { 'FINISHED' }
+        

--- a/mmd_tools/operators/morph.py
+++ b/mmd_tools/operators/morph.py
@@ -126,8 +126,6 @@ class AddVertexMorph(Operator, _AddMorphBase):
     name_j = _AddMorphBase.name_j
     name_e = _AddMorphBase.name_e
     category = _AddMorphBase.category
-    on_active_mesh = bpy.props.BoolProperty(name='On Active Mesh', default=False,
-                                            description='This is an experimental feature.') 
 
     def execute(self, context):
         obj = context.active_object
@@ -135,7 +133,7 @@ class AddVertexMorph(Operator, _AddMorphBase):
         rig = mmd_model.Model(root)
         mmd_root = root.mmd_root
         meshObj = None
-        if self.on_active_mesh:
+        if mmd_root.advanced_mode:
             if obj.type == 'MESH' and obj.mmd_type == 'NONE':
                 meshObj = obj
             else:
@@ -187,6 +185,13 @@ class AddMaterialOffset(Operator):
         rig = mmd_model.Model(root)
         mmd_root = root.mmd_root
         meshObj = rig.firstMesh()
+        if mmd_root.advanced_mode:
+            if obj.type == 'MESH' and obj.mmd_type == 'NONE':
+                meshObj = obj
+            else:
+                self.report({ 'ERROR' }, "The active object is not a valid mesh")
+                return { 'CANCELLED' }
+
         if meshObj is None:
             self.report({ 'ERROR' }, "The model mesh can't be found")
             return { 'CANCELLED' }
@@ -210,8 +215,10 @@ class AddMaterialOffset(Operator):
             
         morph = mmd_root.material_morphs[mmd_root.active_morph]
         mat_data = morph.data.add()
+        mat_data.related_mesh = meshObj.data.name
         mat_data.material = orig_mat.name
         morph.active_material_data = len(morph.data)-1
+        mmd_root.editing_morph = True
         return { 'FINISHED' }
     
 class RemoveMaterialOffset(Operator):
@@ -226,13 +233,23 @@ class RemoveMaterialOffset(Operator):
         rig = mmd_model.Model(root)
         mmd_root = root.mmd_root
         meshObj = rig.firstMesh()
-        if meshObj is None:
-            self.report({ 'ERROR' }, "The model mesh can't be found")
-            return { 'CANCELLED' }
+
         morph = mmd_root.material_morphs[mmd_root.active_morph]
         if len(morph.data) == 0:
             return { 'FINISHED' }
         mat_data = morph.data[morph.active_material_data]
+
+        if mmd_root.advanced_mode:
+            relMesh = rig.findMesh(mat_data.related_mesh)
+            if relMesh is not None:
+                meshObj = relMesh
+            else:
+                self.report({ 'ERROR' }, "The related mesh can't be found")
+                return { 'CANCELLED' }
+        
+        if meshObj is None:
+            self.report({ 'ERROR' }, "The model mesh can't be found")
+            return { 'CANCELLED' }        
         work_mat_name = mat_data.material+"_temp"
         if work_mat_name in meshObj.data.materials.keys():
             base_idx = meshObj.data.materials.find(mat_data.material)
@@ -246,6 +263,7 @@ class RemoveMaterialOffset(Operator):
             bpy.data.materials.remove(mat)
         morph.data.remove(morph.active_material_data)
         morph.active_material_data = max(0, morph.active_material_data-1)
+        mmd_root.editing_morph = False
         return { 'FINISHED' }
         
 class ApplyMaterialOffset(Operator):
@@ -260,11 +278,19 @@ class ApplyMaterialOffset(Operator):
         rig = mmd_model.Model(root)
         mmd_root = root.mmd_root
         meshObj = rig.firstMesh()
+        morph = mmd_root.material_morphs[mmd_root.active_morph]
+        mat_data = morph.data[morph.active_material_data]
+        if mmd_root.advanced_mode:
+            relMesh = rig.findMesh(mat_data.related_mesh)
+            if relMesh is not None:
+                meshObj = relMesh
+            else:
+                self.report({ 'ERROR' }, "The related mesh can't be found")
+                return { 'CANCELLED' }
+
         if meshObj is None:
             self.report({ 'ERROR' }, "The model mesh can't be found")
             return { 'CANCELLED' }
-        morph = mmd_root.material_morphs[mmd_root.active_morph]
-        mat_data = morph.data[morph.active_material_data]
         base_mat = meshObj.data.materials[mat_data.material]
         work_mat = meshObj.data.materials[base_mat.name+"_temp"]
         base_idx = meshObj.data.materials.find(base_mat.name)
@@ -306,6 +332,7 @@ class ApplyMaterialOffset(Operator):
 
         mat = meshObj.data.materials.pop(index=copy_idx)
         bpy.data.materials.remove(mat)
+        mmd_root.editing_morph = False
         return { 'FINISHED' }
     
 class CreateWorkMaterial(Operator):
@@ -320,11 +347,20 @@ class CreateWorkMaterial(Operator):
         rig = mmd_model.Model(root)
         mmd_root = root.mmd_root
         meshObj = rig.firstMesh()
+        morph = mmd_root.material_morphs[mmd_root.active_morph]
+        mat_data = morph.data[morph.active_material_data]
+
+        if mmd_root.advanced_mode:
+            relMesh = rig.findMesh(mat_data.related_mesh)
+            if relMesh is not None:
+                meshObj = relMesh
+            else:
+                self.report({ 'ERROR' }, "The related mesh can't be found")
+                return { 'CANCELLED' }
+
         if meshObj is None:
             self.report({ 'ERROR' }, "The model mesh can't be found")
             return { 'CANCELLED' }
-        morph = mmd_root.material_morphs[mmd_root.active_morph]
-        mat_data = morph.data[morph.active_material_data]
         base_mat = meshObj.data.materials[mat_data.material]
         work_mat = base_mat.copy()
         work_mat.name = base_mat.name+"_temp"     
@@ -365,6 +401,7 @@ class CreateWorkMaterial(Operator):
             work_mmd_mat.edge_color = list(edge_offset)
             work_mmd_mat.edge_weight += mat_data.edge_weight
 
+        mmd_root.editing_morph = True
         return { 'FINISHED' }
 class ClearTempMaterials(Operator):
     bl_idname = 'mmd_tools.clear_temp_materials'
@@ -393,7 +430,8 @@ class ClearTempMaterials(Operator):
                             poly.material_index = base_idx
                     mat = meshObj.data.materials.pop(index=temp_idx)
                     bpy.data.materials.remove(mat)
-                
+
+        root.mmd_root.editing_morph = False
         return { 'FINISHED' }
     
 class AddBoneMorph(Operator, _AddMorphBase):

--- a/mmd_tools/operators/morph.py
+++ b/mmd_tools/operators/morph.py
@@ -126,13 +126,23 @@ class AddVertexMorph(Operator, _AddMorphBase):
     name_j = _AddMorphBase.name_j
     name_e = _AddMorphBase.name_e
     category = _AddMorphBase.category
+    on_active_mesh = bpy.props.BoolProperty(name='On Active Mesh', default=False,
+                                            description='This is an experimental feature.') 
 
     def execute(self, context):
         obj = context.active_object
         root = mmd_model.Model.findRoot(obj)
         rig = mmd_model.Model(root)
         mmd_root = root.mmd_root
-        meshObj = rig.firstMesh()
+        meshObj = None
+        if self.on_active_mesh:
+            if obj.type == 'MESH' and obj.mmd_type == 'NONE':
+                meshObj = obj
+            else:
+                self.report({ 'ERROR' }, "The active object is not a valid mesh")
+                return { 'CANCELLED' }
+
+        meshObj = meshObj or rig.firstMesh()        
         if meshObj is None:
             self.report({ 'ERROR' }, "The model mesh can't be found")
             return { 'CANCELLED' }

--- a/mmd_tools/panels/tool.py
+++ b/mmd_tools/panels/tool.py
@@ -38,9 +38,9 @@ class MMDToolsObjectPanel(_PanelBase, Panel):
 
         root = mmd_model.Model.findRoot(active_obj)
         if root:
-            col = self.layout.column(align=True)
-            col.label('Options:')
-            col.prop(root.mmd_root, 'advanced_mode')
+            # col = self.layout.column(align=True)
+            # col.label('Options:')
+            # col.prop(root.mmd_root, 'advanced_mode')
             col = self.layout.column(align=True)            
             col.label('Rigidbody:')
             row = col.row(align=True)
@@ -341,7 +341,6 @@ class MMDMorphToolsPanel(_PanelBase, Panel):
 
     def _draw_material_data(self, context, rig, col, morph):
         meshObj = rig.firstMesh()
-        mmd_root = rig.rootObject().mmd_root
 
         if meshObj is None:
             c = col.column(align=True)
@@ -367,11 +366,11 @@ class MMDMorphToolsPanel(_PanelBase, Panel):
             return # If the list is empty we should stop drawing the panel here
         data = morph.data[morph.active_material_data]
         c_mat = col.column(align=True)
-        if mmd_root.advanced_mode:
-            c_mat.prop_search(data, 'related_mesh', bpy.data, 'meshes')
-            # Switch to the related mesh here if found
-            relMesh = rig.findMesh(data.related_mesh)
-            meshObj = relMesh or meshObj
+        # if mmd_root.advanced_mode:
+        c_mat.prop_search(data, 'related_mesh', bpy.data, 'meshes')
+        # Switch to the related mesh here if found
+        relMesh = rig.findMesh(data.related_mesh)
+        meshObj = relMesh or meshObj
         
         c_mat.prop_search(data, 'material', meshObj.data, 'materials')
 

--- a/mmd_tools/panels/tool.py
+++ b/mmd_tools/panels/tool.py
@@ -31,6 +31,7 @@ class MMDToolsObjectPanel(_PanelBase, Panel):
         col = layout.column(align=True)
         col.operator(operators.material.ConvertMaterialsForCycles.bl_idname, text='Convert Materials For Cycles')
         col.operator('mmd_tools.separate_by_materials', text='Separate By Materials')
+        col.operator(operators.misc.JoinMeshes.bl_idname)
 
         if active_obj is None:
             return

--- a/mmd_tools/panels/tool.py
+++ b/mmd_tools/panels/tool.py
@@ -39,6 +39,9 @@ class MMDToolsObjectPanel(_PanelBase, Panel):
         root = mmd_model.Model.findRoot(active_obj)
         if root:
             col = self.layout.column(align=True)
+            col.label('Options:')
+            col.prop(root.mmd_root, 'advanced_mode')
+            col = self.layout.column(align=True)            
             col.label('Rigidbody:')
             row = col.row(align=True)
             row.operator('mmd_tools.build_rig')
@@ -338,6 +341,8 @@ class MMDMorphToolsPanel(_PanelBase, Panel):
 
     def _draw_material_data(self, context, rig, col, morph):
         meshObj = rig.firstMesh()
+        mmd_root = rig.rootObject().mmd_root
+
         if meshObj is None:
             c = col.column(align=True)
             c.label("The model mesh can't be found", icon='ERROR')
@@ -362,6 +367,12 @@ class MMDMorphToolsPanel(_PanelBase, Panel):
             return # If the list is empty we should stop drawing the panel here
         data = morph.data[morph.active_material_data]
         c_mat = col.column(align=True)
+        if mmd_root.advanced_mode:
+            c_mat.prop_search(data, 'related_mesh', bpy.data, 'meshes')
+            # Switch to the related mesh here if found
+            relMesh = rig.findMesh(data.related_mesh)
+            meshObj = relMesh or meshObj
+        
         c_mat.prop_search(data, 'material', meshObj.data, 'materials')
 
         base_mat_name = data.material

--- a/mmd_tools/properties/morph.py
+++ b/mmd_tools/properties/morph.py
@@ -161,7 +161,7 @@ class MaterialMorphData(PropertyGroup):
     """
     related_mesh = StringProperty(
         name='Related Mesh',
-        description='Stores a reference to the mesh where this morph belongs to',
+        description='Stores a reference to the mesh where this morph data belongs to',
         set=_set_related_mesh,
         get=_get_related_mesh,
         )

--- a/mmd_tools/properties/morph.py
+++ b/mmd_tools/properties/morph.py
@@ -147,11 +147,24 @@ def _set_material(prop, value):
     mat = bpy.data.materials[value]
     fnMat = FnMaterial(mat)
     prop['material_id'] = fnMat.material_id
-
+    
+def _set_related_mesh(prop, value):
+    rig = FnModel(prop.id_data)
+    if rig.findMesh(value):
+        prop['related_mesh'] = value
+        
+def _get_related_mesh(prop):
+    return prop.get('related_mesh', '')
     
 class MaterialMorphData(PropertyGroup):
     """
     """
+    related_mesh = StringProperty(
+        name='Related Mesh',
+        description='Stores a reference to the mesh where this morph belongs to',
+        set=_set_related_mesh,
+        get=_get_related_mesh,
+        )
     offset_type = EnumProperty(
         name='Offset Type',
         items=[

--- a/mmd_tools/properties/root.py
+++ b/mmd_tools/properties/root.py
@@ -209,11 +209,11 @@ class MMDRoot(PropertyGroup):
         default='',
         )
 
-    advanced_mode = BoolProperty(
-        name='Advanced Mode',
-        description='This option enables advanced and experimental features',
-        default=False,
-        )
+#     advanced_mode = BoolProperty(
+#         name='Advanced Mode',
+#         description='This option enables advanced and experimental features',
+#         default=False,
+#         )
 
     show_meshes = BoolProperty(
         name='Show Meshes',
@@ -342,9 +342,10 @@ class MMDRoot(PropertyGroup):
         min=0,
         default=0
         )
-    editing_morph = BoolProperty(
+    editing_morphs = IntProperty(
         name='Editing Morph',
         description=('Internal property used to indicate that a morph is being viewed or edited. ' +
                      'This is used as safety check to prevent some operations.'),
-        default=False,
+        default=0, 
+        min=0,
         )

--- a/mmd_tools/properties/root.py
+++ b/mmd_tools/properties/root.py
@@ -209,6 +209,12 @@ class MMDRoot(PropertyGroup):
         default='',
         )
 
+    advanced_mode = BoolProperty(
+        name='Advanced Mode',
+        description='This option enables advanced and experimental features',
+        default=False,
+        )
+
     show_meshes = BoolProperty(
         name='Show Meshes',
         update=_toggleVisibilityOfMeshes,
@@ -322,11 +328,11 @@ class MMDRoot(PropertyGroup):
         name='Active Morph Type',
         description='Active Morph Type',
         items = [
-            ('material_morphs', 'Material', '', 0),
-            ('uv_morphs', 'UV', '', 1),
-            ('bone_morphs', 'Bone', '', 2),
-            ('vertex_morphs', 'Vertex', '', 3),
-            ('group_morphs', 'Group', '', 4),
+            ('material_morphs', 'MAT', 'Material Morphs', 0),
+            ('uv_morphs', 'UV', 'UV Morphs', 1),
+            ('bone_morphs', 'BONE', 'Bone Morphs', 2),
+            ('vertex_morphs', 'VTX', 'Vertex Morphs', 3),
+            ('group_morphs', 'GRP', 'Group Morphs', 4),
             ],
         default='vertex_morphs',
         update=_activeMorphReset
@@ -335,4 +341,10 @@ class MMDRoot(PropertyGroup):
         name='Active Morph',
         min=0,
         default=0
+        )
+    editing_morph = BoolProperty(
+        name='Editing Morph',
+        description=('Internal property used to indicate that a morph is being viewed or edited. ' +
+                     'This is used as safety check to prevent some operations.'),
+        default=False,
         )

--- a/mmd_tools/utils.py
+++ b/mmd_tools/utils.py
@@ -116,6 +116,17 @@ def separateByMaterials(meshObj):
             i.name = mat.name
             i.parent = prev_parent
 
+def clearUnusedMeshes():
+    import bpy
+    meshes_to_delete = []
+    for mesh in bpy.data.meshes:
+        if mesh.users == 0:
+            meshes_to_delete.append(mesh)
+
+    for mesh in meshes_to_delete:
+        bpy.data.meshes.remove(mesh)
+    
+
 
 ## Boneのカスタムプロパティにname_jが存在する場合、name_jの値を
 # それ以外の場合は通常のbone名をキーとしたpose_boneへの辞書を作成


### PR DESCRIPTION
Hello, I have been working on Multi-Mesh support for Morphs. I have noticed you have been working too, is good to see you are really active. Hopefully, this time it seems there are no conflicting changes. 

I had split it in 2 commits. In @4bd4b82 I just implemented multi-mesh for Vertex Morphs, it was very easy since the vertex morphs are just used to store metadata of the ShapeKeys. So I just added some logic to the `AddVertexMorph` operator to use the active mesh if the option is provided. On the same commit I also implemented a simple `JoinMeshes` operator, the idea is to provide a reverse operator for `SeparateByMaterials`.

The other one is much bigger because the problem is more complex. The limitation of just using the first mesh was there because we need to create temporary materials, and we need to know _where_ to store them. The solution that I thought was adding a property to the `MaterialMorphData` to store a reference to the mesh, so if the user change the active mesh we will know where to look. 

Here is a list of all the changes that I have made:
## New Features
- Added a property to the `mmd_root` to switch between standard and advanced mode. In advanced mode experimental features are also enabled.
- Added an internal property to the `mmd_root` to track whether the user is currently viewing/editing a morph (or more specifically a offset). This is used as a safety check to prevent some actions such as export, separate by material...
- Made necessary changes to the Morphs operators to use the new properties
## Minor Changes
- Added helper method on the `core.Model` to find a mesh by name
- Changed the labels of the `active_morph_type` to save space on the panel
- Added simple method to clear unused meshes (`mesh.users == 0`)
## Known Issues
- If a model has Material Morphs and then is separated by material we need to update the references to the new meshes. The same is true for the reverse path, we need to update the material morphs to point to the new single mesh.
- If the user changes the name of the mesh we can't sync it with morph data, a similar issue happens to the ShapeKeys, actually there is no way around it. But the panel stops drawing if the related mesh is not found.

Actually the issue with updating the mesh references should be easy to solve. But I was unsure of where should that code be. I suggest to create a module under `mmd_tools.core` called `morphs` and place there util functions and classes related to the morphs. We should move there the logic of swapping the materials of a mesh (used by Material Morphs operators). There will be also functions to update the related mesh references. I wanted to discuss it first before implementing them.
