### PR TITLE
Added preference to specify a base folder for textures.

### DIFF
--- a/mmd_tools/__init__.py
+++ b/mmd_tools/__init__.py
@@ -40,9 +40,6 @@ bl_info= {
 
 logging.basicConfig(format='%(message)s')
 
-def addon_preferences(attrname, default=None):
-    addon = bpy.context.user_preferences.addons.get(__name__, None)
-    return getattr(addon.preferences, attrname, default) if addon else default
 
 class MMDToolsAddonPreferences(AddonPreferences):
     # this must match the addon name, use '__package__'
@@ -51,12 +48,21 @@ class MMDToolsAddonPreferences(AddonPreferences):
 
     shared_toon_folder = StringProperty(
             name="Shared Toon Texture Folder",
+            description=('Directory path to toon textures. This is normally the ' +
+                         '"Data" directory within of your MikuMikuDance directory'),
+            subtype='DIR_PATH',
+            )
+    base_texture_folder = StringProperty(
+            name='Base Texture Folder',
+            description=('This directory path will be used to determine the relative ' +
+                         'path of the textures you use'),
             subtype='DIR_PATH',
             )
 
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "shared_toon_folder")
+        layout.prop(self, "base_texture_folder")
 
 
 def menu_func_import(self, context):

--- a/mmd_tools/bpyutils.py
+++ b/mmd_tools/bpyutils.py
@@ -47,6 +47,10 @@ class __SelectObjects:
         for i, j in zip(self.__selected_objects, self.__hides):
             i.hide = j
 
+def addon_preferences(attrname, default=None):
+    addon = bpy.context.user_preferences.addons.get(__package__, None)
+    return getattr(addon.preferences, attrname, default) if addon else default
+
 def setParent(obj, parent):
     ho = obj.hide
     hp = parent.hide

--- a/mmd_tools/core/material.py
+++ b/mmd_tools/core/material.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import bpy
-import mmd_tools
+from mmd_tools.bpyutils import addon_preferences
 
 SPHERE_MODE_OFF    = 0
 SPHERE_MODE_MULT   = 1
@@ -114,7 +114,7 @@ class FnMaterial(object):
             tex = texture_slot.texture
             self.__material.texture_slots.clear(index)
             #print('clear texture: %s  users: %d'%(tex.name, tex.users))
-            if tex and tex.users < 1:
+            if tex and tex.users < 1 and tex.type == 'IMAGE':
                 #print(' - remove texture: '+tex.name)
                 img = tex.image
                 tex.image = None
@@ -192,7 +192,7 @@ class FnMaterial(object):
     def update_toon_texture(self):
         mmd_mat = self.__material.mmd_material
         if mmd_mat.is_shared_toon_texture:
-            shared_toon_folder = mmd_tools.addon_preferences('shared_toon_folder', '')
+            shared_toon_folder = addon_preferences('shared_toon_folder', '')
             toon_path = os.path.join(shared_toon_folder, 'toon%02d.bmp'%(mmd_mat.shared_toon_texture+1))
             self.create_toon_texture(bpy.path.resolve_ncase(path=toon_path))
         elif mmd_mat.toon_texture != '':

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -152,16 +152,23 @@ class __PmxExporter:
         return len(self.__model.textures) - 1
 
     def __copy_textures(self, tex_dir):
-        if not os.path.isdir(tex_dir):
-            os.mkdir(tex_dir)
-            logging.info('Create a texture directory: %s', tex_dir)
-
+        tex_dir_fallback = os.path.join(tex_dir, 'textures')
         for texture in self.__model.textures:
             path = texture.path
-            dest_path = os.path.join(tex_dir, os.path.basename(path))
+            base_folder = bpyutils.addon_preferences('base_texture_folder', '')
+            dst_name = os.path.basename(path)
+            if base_folder != '':
+                dst_name = os.path.relpath(path, base_folder)
+                if dst_name.startswith('..'):
+                    logging.warning('The texture %s is not inside the base texture folder', path)
+                    # Fall back to basename and textures folder
+                    dst_name = os.path.basename(path)
+                    tex_dir = tex_dir_fallback
+            dest_path = os.path.join(tex_dir, dst_name)
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
             if not os.path.isfile(path):
                 logging.warning('*** skipping texture file which does not exist: %s', path)
-            else:                        
+            elif path != dest_path:  # Only copy if the paths are different                        
                 shutil.copyfile(path, dest_path)
                 logging.info('Copy file %s --> %s', path, dest_path)
             texture.path = dest_path
@@ -931,7 +938,9 @@ class __PmxExporter:
             self.__exportDisplayItems(root, nameMap)
 
         if self.__copyTextures:
-            tex_dir = os.path.join(os.path.dirname(filepath), 'textures')
+            tex_dir = os.path.dirname(filepath)
+            if not bpyutils.addon_preferences('base_texture_folder', ''):
+                tex_dir = os.path.join(tex_dir, 'textures') 
             self.__copy_textures(tex_dir)
 
         pmx.save(filepath, self.__model)

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -164,6 +164,8 @@ class __PmxExporter:
                     # Fall back to basename and textures folder
                     dst_name = os.path.basename(path)
                     tex_dir = tex_dir_fallback
+            else:
+                tex_dir = tex_dir_fallback
             dest_path = os.path.join(tex_dir, dst_name)
             os.makedirs(os.path.dirname(dest_path), exist_ok=True)
             if not os.path.isfile(path):
@@ -939,8 +941,6 @@ class __PmxExporter:
 
         if self.__copyTextures:
             tex_dir = os.path.dirname(filepath)
-            if not bpyutils.addon_preferences('base_texture_folder', ''):
-                tex_dir = os.path.join(tex_dir, 'textures') 
             self.__copy_textures(tex_dir)
 
         pmx.save(filepath, self.__model)

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -260,9 +260,6 @@ class ExportPmx(Operator, ExportHelper):
             bpy.ops.pose.transforms_clear()
             bpy.ops.object.mode_set(mode='OBJECT')
             root.mmd_root.show_armature = prev_show
-        # Add extension if needed
-        if not self.filepath.endswith(self.filename_ext):
-            self.filepath += self.filename_ext 
         try:
             pmx_exporter.export(
                 filepath=self.filepath,

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -260,6 +260,9 @@ class ExportPmx(Operator, ExportHelper):
             bpy.ops.pose.transforms_clear()
             bpy.ops.object.mode_set(mode='OBJECT')
             root.mmd_root.show_armature = prev_show
+        # Add extension if needed
+        if not self.filepath.endswith(self.filename_ext):
+            self.filepath += self.filename_ext 
         try:
             pmx_exporter.export(
                 filepath=self.filepath,

--- a/mmd_tools/operators/misc.py
+++ b/mmd_tools/operators/misc.py
@@ -50,27 +50,35 @@ class JoinMeshes(Operator):
         obj = context.active_object
         root = mmd_model.Model.findRoot(obj)
         if root is None:
-            self.report({ 'ERROR' }, 'Select a MMD model') 
-            return { 'CANCELLED' } 
+            # self.report({ 'ERROR' }, 'Select a MMD model') 
+            # return { 'CANCELLED' }
+            # find all meshes in the active layer
+            act_layer = bpy.context.scene.active_layer
+            meshes_list = [o for o in bpy.data.objects
+                           if o.layers[act_layer] and o.type == 'MESH' and o.mmd_type == 'NONE']
+            active_mesh = meshes_list[0]
+        else:
+            # Find all the meshes in mmd_root
+            rig = mmd_model.Model(root)
+            meshes_list = rig.meshes()
+            active_mesh = rig.firstMesh()
 
-        if root.mmd_root.editing_morphs > 0:            
+        if root and root.mmd_root.editing_morphs > 0:            
             bpy.ops.mmd_tools.clear_temp_materials()
             bpy.ops.mmd_tools.clear_uv_morph_view()        
             self.report({ 'WARNING' }, "Active editing morphs were cleared")
             # return { 'CANCELLED' }
-        # Find all the meshes in mmd_root and join them          
-        rig = mmd_model.Model(root)
+        # Join selected meshes
         bpy.ops.object.select_all(action='DESELECT')
-        for mesh in rig.meshes():
+        for mesh in meshes_list:
             mesh.hide = False
             mesh.select = True
-        bpy.context.scene.objects.active = rig.firstMesh()        
+        bpy.context.scene.objects.active = active_mesh
         bpy.ops.object.join()
-        if len(root.mmd_root.material_morphs) > 0:
+        if root and len(root.mmd_root.material_morphs) > 0:
             for morph in root.mmd_root.material_morphs:
                 mo = FnMorph(morph, rig)
                 mo.update_mat_related_mesh(rig.firstMesh())
-                
 
         utils.clearUnusedMeshes()
         return { 'FINISHED' }

--- a/mmd_tools/operators/misc.py
+++ b/mmd_tools/operators/misc.py
@@ -50,20 +50,15 @@ class JoinMeshes(Operator):
         obj = context.active_object
         root = mmd_model.Model.findRoot(obj)
         if root is None:
-            # self.report({ 'ERROR' }, 'Select a MMD model') 
-            # return { 'CANCELLED' }
-            # find all meshes in the active layer
-            act_layer = bpy.context.scene.active_layer
-            meshes_list = [o for o in bpy.data.objects
-                           if o.layers[act_layer] and o.type == 'MESH' and o.mmd_type == 'NONE']
-            active_mesh = meshes_list[0]
-        else:
-            # Find all the meshes in mmd_root
-            rig = mmd_model.Model(root)
-            meshes_list = rig.meshes()
-            active_mesh = rig.firstMesh()
+            self.report({ 'ERROR' }, 'Select a MMD model') 
+            return { 'CANCELLED' }
+        
+        # Find all the meshes in mmd_root
+        rig = mmd_model.Model(root)
+        meshes_list = rig.meshes()
+        active_mesh = rig.firstMesh()
 
-        if root and root.mmd_root.editing_morphs > 0:            
+        if root.mmd_root.editing_morphs > 0:            
             bpy.ops.mmd_tools.clear_temp_materials()
             bpy.ops.mmd_tools.clear_uv_morph_view()        
             self.report({ 'WARNING' }, "Active editing morphs were cleared")
@@ -75,11 +70,40 @@ class JoinMeshes(Operator):
             mesh.select = True
         bpy.context.scene.objects.active = active_mesh
         bpy.ops.object.join()
-        if root and len(root.mmd_root.material_morphs) > 0:
+        if len(root.mmd_root.material_morphs) > 0:
             for morph in root.mmd_root.material_morphs:
                 mo = FnMorph(morph, rig)
                 mo.update_mat_related_mesh(rig.firstMesh())
 
         utils.clearUnusedMeshes()
         return { 'FINISHED' }
+
+class AttachMeshesToMMD(Operator):
+    bl_idname = 'mmd_tools.attach_meshes_to_mmd'
+    bl_label = 'Attach Meshes to Model'
+    bl_description = 'Finds existing meshes and attaches them to the selected MMD model'
+    bl_options = {'PRESET'}
+    
+    @classmethod
+    def poll(cls, context):
+        obj = context.active_object
+        return mmd_model.Model.findRoot(obj) is not None
+
+    def execute(self, context):
+        root = mmd_model.Model.findRoot(context.active_object)
+        rig = mmd_model.Model(root)
+        armObj = rig.armature()
+        if armObj is None:
+            self.report({ 'ERROR' }, 'Model Armature not found')
+            return { 'CANCELLED' }
+        act_layer = bpy.context.scene.active_layer
+        meshes_list = (o for o in bpy.context.scene.objects 
+                       if o.layers[act_layer] and o.type == 'MESH' and o.mmd_type == 'NONE')
+        for mesh in meshes_list:
+            if mmd_model.Model.findRoot(mesh) is not None:
+                # Do not attach meshes from other models
+                continue
+            mesh.parent = armObj
+        return { 'FINISHED' }
+            
         

--- a/mmd_tools/panels/tool.py
+++ b/mmd_tools/panels/tool.py
@@ -32,6 +32,7 @@ class MMDToolsObjectPanel(_PanelBase, Panel):
         col.operator(operators.material.ConvertMaterialsForCycles.bl_idname, text='Convert Materials For Cycles')
         col.operator('mmd_tools.separate_by_materials', text='Separate By Materials')
         col.operator(operators.misc.JoinMeshes.bl_idname)
+        col.operator(operators.misc.AttachMeshesToMMD.bl_idname)
 
         if active_obj is None:
             return


### PR DESCRIPTION
That preference is used to determine the relative paths. 
Example:
Base Texture folder is `C:\Users\lordscales91\Pictures\textures`
A model has 2 textures: a main texture at `C:\Users\lordscales91\Pictures\textures\tex\body0.png` and as sphere map texture at `C:\Users\lordscales91\Pictures\textures\sph\lotion.sph`

The relatives paths will be `tex\body0.png` and `sph\lotion.sph`. So, this allows you to tweak the directory layout of the model. If a texture is not inside the configured base texture folder the code fallback to `textures\<basename>`

Here is a complete list of changes:
## Improvements
- Customization of the texture directory layout
- Operator JoinMeshes now will join all meshes in the active layer if mmd_root is not found
- The function `addon_preferences` was moved to `bpyutils` module
## Fixes
- The texture files will only be copied if the destination path is different from the source.
- (*.pmx) extension automatically added when saving.
- When removing a texture from `bpy.data.images` added a safety check to ensure the texture was an image.
