### PR TITLE
Implemented first unit test

### DIFF
--- a/tests/test_model_operators.py
+++ b/tests/test_model_operators.py
@@ -1,0 +1,61 @@
+import unittest
+from base64 import b64decode
+
+import bpy
+
+from mmd_tools.core.model import Model
+
+# Usage: blender --background -noaudio --python tests/test_model_operators.py -- --verbose
+
+# Due to the limitations of Windows this file can't contain characters
+# outside the cp1252 range. Because Blender parses the file with that character set.
+# http://stackoverflow.com/questions/3284827
+# https://developer.blender.org/T35176
+
+# A workaround is to use Base64 encoded bytestrings
+# Root bone
+ROOT_BONE = b64decode(b'5YWo44Gm44Gu6Kaq').decode('utf8')
+# Facial Frame
+EXP_FRAME = b64decode(b'6KGo5oOF').decode('utf8')
+
+class ModelOperatorsTest(unittest.TestCase):
+    
+    def setUp(self):
+        """
+        We should start each test with a clean state
+        """
+        bpy.ops.object.mode_set(mode='OBJECT')
+        bpy.ops.object.select_all(action='SELECT')
+        bpy.ops.object.delete(use_global=True)
+        # Add some useful shortcuts
+        self.context = bpy.context
+        self.scene = bpy.context.scene
+
+    def test_create_model(self):
+        bpy.ops.mmd_tools.create_mmd_model_root_object(name_j='Test', name_e='Test_e')
+        self.assertIn('Test', self.scene.objects.keys(), 'Model not found')
+        # Check the object has the expected data
+        obj = self.scene.objects['Test']
+        root = Model.findRoot(obj)
+        self.assertIsNotNone(root, 'Model not created properly')
+        frames = root.mmd_root.display_item_frames
+        self.assertIn('Root', frames.keys())
+        self.assertIn(EXP_FRAME, frames.keys())
+        # Check the rig has an armature
+        rig = Model(root)
+        self.assertIsNotNone(rig.armature(), 'Armature not found')
+        armObj = rig.armature()
+        self.assertIn(ROOT_BONE, armObj.data.bones.keys(), 'Root bone not found')
+        # Check the root frame has the root bone
+        root_frame = frames['Root']
+        try:
+            item = root_frame.items[0]
+            self.assertEqual(item.name, armObj.data.bones.keys()[0], 'Incorrect Item name')
+            self.assertEqual(item.type, 'BONE', 'Incorrect Item type')
+        except IndexError:
+            self.fail('Root bone not found in root frame')
+
+if __name__ == '__main__':
+    import sys
+    sys.argv = [__file__] + (sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else [])
+    unittest.main()

--- a/tests/test_model_operators.py
+++ b/tests/test_model_operators.py
@@ -1,5 +1,4 @@
 import unittest
-from base64 import b64decode
 
 import bpy
 
@@ -12,11 +11,11 @@ from mmd_tools.core.model import Model
 # http://stackoverflow.com/questions/3284827
 # https://developer.blender.org/T35176
 
-# A workaround is to use Base64 encoded bytestrings
+# A workaround is to use unicode literals
 # Root bone
-ROOT_BONE = b64decode(b'5YWo44Gm44Gu6Kaq').decode('utf8')
+ROOT_BONE = '\u5168\u3066\u306e\u89aa'
 # Facial Frame
-EXP_FRAME = b64decode(b'6KGo5oOF').decode('utf8')
+EXP_FRAME = '\u8868\u60c5'
 
 class ModelOperatorsTest(unittest.TestCase):
     


### PR DESCRIPTION
Well, I have managed to implement the first unit test. It's a test for the `CreateMMDModelRoot` operator. I have described there in the comments the usage for that test but this is the general rule:

`blender [blender args...] --python <script file> -- [script arguments...]` 
- `--background` is used to execute Blender without the UI
- `-noaudio` is used to disable audio in Blender
- `--verbose` is passed to the test script and tells [unittest](https://docs.python.org/3/library/unittest.html#cmdoption-unittest-discover-v) to give a verbose output

I was about to implement tests for the rest of the model operators. But those would require some sample data and I was unsure about what should be the best approach to distribute those samples among developers. 

The easiest approach would be to just put them in the repository but. Repositories should only contain source code if possible. So, my idea is to upload the samples to some server (Dropbox, Onedrive, Google Drive...) and then place on the repository the download links. The drawback of this option is that the download links may be unavailable and automatize the download can be troublesome. What do you think?

Additional note: It is not necessary to use unittest for the test scripts, they could be just simple scripts that process some data and check the results, but unittest should be preferred.
