### PR TITLE
Implemented material and mesh sorter

### DIFF
--- a/mmd_tools/core/exceptions.py
+++ b/mmd_tools/core/exceptions.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+# Module for custom exceptions
+
+class MaterialNotFoundError(Exception):
+    pass
+
+class DivisionError(Exception):
+    pass

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -398,6 +398,25 @@ class Model:
                 return mesh
         return None
 
+    def findMeshByIndex(self, index):
+        """
+        Helper method to find the mesh by index
+        """
+        for i, mesh in enumerate(self.meshes()):
+            if i == index:
+                return mesh
+
+        return None
+
+    def getMeshIndex(self, mesh_name):
+        """
+        Helper method to get the index of a mesh. Returns -1 if not found
+        """
+        for i, mesh in enumerate(self.meshes()):
+            if mesh.name == mesh_name or mesh.data.name == mesh_name:
+                return i
+        return -1
+
     def rigidBodies(self):
         return filter(isRigidBodyObject, self.allObjects(self.rigidGroupObject()))
 

--- a/mmd_tools/operators/material.py
+++ b/mmd_tools/operators/material.py
@@ -4,8 +4,8 @@ from bpy.types import Operator
 from bpy.props import StringProperty, BoolProperty
 
 from mmd_tools.core.material import FnMaterial
+from mmd_tools.core.exceptions import MaterialNotFoundError
 from mmd_tools import cycles_converter
-from mmd_tools import bpyutils
 
 class ConvertMaterialsForCycles(Operator):
     bl_idname = 'mmd_tools.convert_materials_for_cycles'
@@ -110,23 +110,13 @@ class MoveMaterialUp(Operator):
         obj = context.active_object
         current_idx = obj.active_material_index
         prev_index = current_idx - 1
-        # save a reference to the materials
-        mat = obj.data.materials[current_idx]
-        prev_mat = obj.data.materials[prev_index]
-        if None in (mat, prev_mat):
-            self.report({'ERROR'}, 'Materials not valid')
+        try:
+            FnMaterial.swap_materials(obj, current_idx, prev_index,
+                                      reverse=True, swap_slots=True)
+        except MaterialNotFoundError:
+            self.report({'ERROR'}, 'Materials not found')
             return { 'CANCELLED' }
-        # Swap the assigned polygons
-        with bpyutils.select_object(obj):
-            for poly in obj.data.polygons:
-                if poly.material_index == current_idx:
-                    poly.material_index = prev_index
-                elif poly.material_index == prev_index:
-                    poly.material_index = current_idx
-            # Swap the material slots
-            obj.material_slots[prev_index].material = mat
-            obj.material_slots[current_idx].material = prev_mat
-            obj.active_material_index = prev_index
+        obj.active_material_index = prev_index
 
         return { 'FINISHED' }
 
@@ -146,22 +136,11 @@ class MoveMaterialDown(Operator):
         obj = context.active_object
         current_idx = obj.active_material_index
         next_index = current_idx + 1
-        # save a reference to the materials
-        mat = obj.data.materials[current_idx]
-        next_mat = obj.data.materials[next_index]
-        if None in (mat, next_mat):
-            self.report({'ERROR'}, 'Materials not valid')
+        try:
+            FnMaterial.swap_materials(obj, current_idx, next_index,
+                                      reverse=True, swap_slots=True)
+        except MaterialNotFoundError:
+            self.report({'ERROR'}, 'Materials not found')
             return { 'CANCELLED' }
-        # Swap the assigned polygons
-        with bpyutils.select_object(obj):
-            for poly in obj.data.polygons:
-                if poly.material_index == current_idx:
-                    poly.material_index = next_index
-                elif poly.material_index == next_index:
-                    poly.material_index = current_idx
-            # Swap the material slots
-            obj.material_slots[next_index].material = mat
-            obj.material_slots[current_idx].material = next_mat
-            obj.active_material_index = next_index
-
+        obj.active_material_index = next_index
         return { 'FINISHED' }

--- a/mmd_tools/operators/misc.py
+++ b/mmd_tools/operators/misc.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 
+import re
+
 import bpy
 from bpy.types import Operator
 
 from mmd_tools import utils
 from mmd_tools.core import model as mmd_model
 from mmd_tools.core.morph import FnMorph
+from mmd_tools.core.material import FnMaterial
 
+PREFIX_PATT = r'(?P<prefix>[0-9A-Z]{3}_)(?P<name>.*)'
 
 class SeparateByMaterials(Operator):
     bl_idname = 'mmd_tools.separate_by_materials'
@@ -27,7 +31,27 @@ class SeparateByMaterials(Operator):
             bpy.ops.mmd_tools.clear_uv_morph_view()        
             self.report({ 'WARNING' }, "Active editing morphs were cleared")
             # return { 'CANCELLED' }
+        if root:
+            # Store the current material names
+            rig = mmd_model.Model(root)
+            mat_names = [mat.name for mat in rig.materials()]
         utils.separateByMaterials(obj)
+        if root:
+            rig = mmd_model.Model(root)
+            # The material morphs store the name of the mesh, not of the object.
+            # So they will not be out of sync
+            for mesh in rig.meshes():
+                if len(mesh.data.materials) == 1:
+                    mat = mesh.data.materials[0]
+                    idx = mat_names.index(mat.name)
+                    prefix = utils.int2base(idx, 36)
+                    prefix = '0'*(3 - len(prefix)) + prefix + '_'
+                    ma = re.match(PREFIX_PATT, mesh.name)
+                    if ma:
+                        mesh.name = prefix + ma.group('name')
+                    else:
+                        mesh.name = prefix + mesh.name
+                        
         if root and len(root.mmd_root.material_morphs) > 0:
             for morph in root.mmd_root.material_morphs:
                 mo = FnMorph(morph, mmd_model.Model(root))
@@ -62,7 +86,9 @@ class JoinMeshes(Operator):
             bpy.ops.mmd_tools.clear_temp_materials()
             bpy.ops.mmd_tools.clear_uv_morph_view()        
             self.report({ 'WARNING' }, "Active editing morphs were cleared")
-            # return { 'CANCELLED' }
+
+        # Store the current order of the materials
+        material_names = [mat.name for mat in rig.materials()]
         # Join selected meshes
         bpy.ops.object.select_all(action='DESELECT')
         for mesh in meshes_list:
@@ -70,6 +96,8 @@ class JoinMeshes(Operator):
             mesh.select = True
         bpy.context.scene.objects.active = active_mesh
         bpy.ops.object.join()
+        # Restore the material order
+        FnMaterial.fixMaterialOrder(rig.firstMesh(), material_names)
         if len(root.mmd_root.material_morphs) > 0:
             for morph in root.mmd_root.material_morphs:
                 mo = FnMorph(morph, rig)
@@ -105,5 +133,86 @@ class AttachMeshesToMMD(Operator):
                 continue
             mesh.parent = armObj
         return { 'FINISHED' }
-            
-        
+
+def _normalize_mesh_names(meshes):
+    """
+    Helper method that sets a prefix for the mesh objects for sorting
+    """    
+    for i, m in enumerate(meshes):        
+        idx = utils.int2base(i, 36)
+        prefix = '0'*(3 - len(idx)) + idx + '_'
+        ma = re.match(PREFIX_PATT, m.name)
+        if ma:
+            m.name = prefix + ma.group('name')
+        else:            
+            m.name = prefix + m.name
+
+def _swap_prefixes(mesh1, mesh2):
+    mesh1_prefix = re.match(PREFIX_PATT, mesh1.name).group('prefix')
+    mesh1_name = re.match(PREFIX_PATT, mesh1.name).group('name')
+    mesh2_prefix = re.match(PREFIX_PATT, mesh2.name).group('prefix')
+    mesh2_name = re.match(PREFIX_PATT, mesh2.name).group('name')
+    mesh1.name = mesh2_prefix + mesh1_name
+    mesh2.name = mesh1_prefix + mesh2_name
+
+class MoveModelMeshUp(Operator):
+    bl_idname = 'mmd_tools.move_mesh_up'
+    bl_label = 'Move Model Mesh Up'
+    bl_description = 'Moves the selected mesh up'
+    bl_options = {'PRESET'}
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.active_object
+        return obj and mmd_model.Model.findRoot(obj)
+
+    def execute(self, context):
+        root = mmd_model.Model.findRoot(context.active_object)
+        rig = mmd_model.Model(root)
+        # First normalize the mesh names
+        _normalize_mesh_names(rig.meshes())
+        try:
+            current_mesh = context.scene.objects[root.mmd_root.active_mesh_index]
+        except Exception:
+            self.report({ 'ERROR' }, 'Mesh not found')
+            return { 'CANCELLED' }
+        # Find the previous mesh
+        prefix = re.match(PREFIX_PATT, current_mesh.name).group('prefix')[:-1]
+        current_idx = int(prefix, 36)
+        prev_mesh = rig.findMeshByIndex(current_idx - 1)
+        if current_mesh and prev_mesh and current_mesh != prev_mesh:
+            # Swap the prefixes
+            _swap_prefixes(current_mesh, prev_mesh)
+
+        return { 'FINISHED' }
+
+class MoveModelMeshDown(Operator):
+    bl_idname = 'mmd_tools.move_mesh_down'
+    bl_label = 'Move Model Mesh Down'
+    bl_description = 'Moves the selected mesh down'
+    bl_options = {'PRESET'}
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.active_object
+        return obj and mmd_model.Model.findRoot(obj)
+
+    def execute(self, context):
+        root = mmd_model.Model.findRoot(context.active_object)
+        rig = mmd_model.Model(root)
+        # First normalize the mesh names
+        _normalize_mesh_names(rig.meshes())
+        try:
+            current_mesh = context.scene.objects[root.mmd_root.active_mesh_index]
+        except Exception:
+            self.report({ 'ERROR' }, 'Mesh not found')
+            return { 'CANCELLED' }
+        # Find the next mesh
+        prefix = re.match(PREFIX_PATT, current_mesh.name).group('prefix')[:-1]
+        current_idx = int(prefix, 36)
+        next_mesh = rig.findMeshByIndex(current_idx + 1)
+        if current_mesh and next_mesh and current_mesh != next_mesh:
+            # Swap the prefixes
+            _swap_prefixes(current_mesh, next_mesh)
+
+        return { 'FINISHED' }

--- a/mmd_tools/operators/morph.py
+++ b/mmd_tools/operators/morph.py
@@ -6,6 +6,8 @@ from mathutils import Vector, Quaternion
 
 import mmd_tools.core.model as mmd_model
 from mmd_tools import bpyutils
+from mmd_tools.core.material import FnMaterial
+from mmd_tools.core.exceptions import MaterialNotFoundError, DivisionError
 from mmd_tools import utils
 
 #Util functions
@@ -18,7 +20,7 @@ def divide_vector_components(vec1, vec2):
             if v1 == 0:
                 v2 = 1 #If we have a 0/0 case we change the divisor to 1
             else:
-                raise ValueError("Invalid Input: a non-zero value can't be divided by zero")
+                raise DivisionError("Invalid Input: a non-zero value can't be divided by zero")
         result.append(v1/v2)
     return result
 
@@ -37,7 +39,7 @@ def special_division(n1, n2):
         if n1 == 0:
             n2 = 1
         else:
-            raise ValueError("Invalid Input: a non-zero value can't be divided by zero")
+            raise DivisionError("Invalid Input: a non-zero value can't be divided by zero")
     return n1/n2
 
 class _AddMorphBase(object):
@@ -180,6 +182,11 @@ class AddMaterialOffset(Operator):
     bl_label = 'Add Material Offset'
     bl_description = ''
     bl_options = {'PRESET'}
+
+    @classmethod
+    def poll(cls, context):
+        root = mmd_model.Model.findRoot(context.active_object)
+        return root and mmd_model.Model(root).firstMesh()
     
     def execute(self, context):
         obj = context.active_object
@@ -193,9 +200,6 @@ class AddMaterialOffset(Operator):
         else:
             self.report({ 'WARNING' }, "The active object is not a valid mesh. The first mesh was used instead")
 
-        if meshObj is None:
-            self.report({ 'ERROR' }, "The model mesh can't be found")
-            return { 'CANCELLED' }
         # Let's create a temporary material to edit the offset
         orig_mat = meshObj.active_material
         if orig_mat is None or "_temp" in orig_mat.name:
@@ -207,13 +211,7 @@ class AddMaterialOffset(Operator):
         copy_mat = orig_mat.copy()
         copy_mat.name = orig_mat.name+"_temp"
         meshObj.data.materials.append(copy_mat)
-        orig_idx = meshObj.active_material_index
-        copy_idx = meshObj.data.materials.find(copy_mat.name)
-        with bpyutils.select_object(meshObj):
-            for poly in meshObj.data.polygons:
-                if poly.material_index == orig_idx:
-                    poly.material_index = copy_idx
-
+        FnMaterial.swap_materials(meshObj, orig_mat.name, copy_mat.name)
         morph = mmd_root.material_morphs[mmd_root.active_morph]
         mat_data = morph.data.add()
         mat_data.related_mesh = meshObj.data.name
@@ -227,45 +225,47 @@ class RemoveMaterialOffset(Operator):
     bl_label = 'Remove Material Offset'
     bl_description = ''
     bl_options = {'PRESET'}
-    
+
+    @classmethod
+    def poll(cls, context):
+        root = mmd_model.Model.findRoot(context.active_object)
+        return root and mmd_model.Model(root).firstMesh()
+
     def execute(self, context):
         obj = context.active_object
         root = mmd_model.Model.findRoot(obj)
         rig = mmd_model.Model(root)
         mmd_root = root.mmd_root
-        meshObj = rig.firstMesh()
 
         morph = mmd_root.material_morphs[mmd_root.active_morph]
         if len(morph.data) == 0:
             return { 'FINISHED' }
         mat_data = morph.data[morph.active_material_data]
-
-        # if mmd_root.advanced_mode:
-        relMesh = rig.findMesh(mat_data.related_mesh)
-        if relMesh is not None:
-            meshObj = relMesh
-        else:
-            self.report({ 'ERROR' }, "The related mesh can't be found")
-            return { 'CANCELLED' }
-        
+        meshObj = rig.findMesh(mat_data.related_mesh)
         if meshObj is None:
             self.report({ 'ERROR' }, "The model mesh can't be found")
-            return { 'CANCELLED' }        
+            return { 'CANCELLED' }
+
         work_mat_name = mat_data.material+"_temp"
-        if work_mat_name in meshObj.data.materials.keys():
-            with bpyutils.select_object(meshObj):
-                base_idx = meshObj.data.materials.find(mat_data.material)
-                copy_idx = meshObj.data.materials.find(work_mat_name)
-                
-                for poly in meshObj.data.polygons:
-                    if poly.material_index == copy_idx:
-                        poly.material_index = base_idx
-                
-                mat = meshObj.data.materials.pop(index=copy_idx)
-                bpy.data.materials.remove(mat)
+        base_mat = None
+        try:
+            copy_mat, base_mat = FnMaterial.swap_materials(meshObj, work_mat_name,
+                                                           mat_data.material)
+        except MaterialNotFoundError:
+            # if the temp material is not found it can be safely ignored
+            # if the base material is not found we should report it
+            if base_mat is None:
+                self.report({ 'WARNING' }, 'Material not found')
+        else:
+            # Only remove the temp material if it has been successfully replaced with the base
+            copy_idx = meshObj.data.materials.find(copy_mat.name)
+            mat = meshObj.data.materials.pop(index=copy_idx)
+            bpy.data.materials.remove(mat)
+
         morph.data.remove(morph.active_material_data)
         morph.active_material_data = max(0, morph.active_material_data-1)
         mmd_root.editing_morphs -= 1
+
         return { 'FINISHED' }
         
 class ApplyMaterialOffset(Operator):
@@ -273,36 +273,36 @@ class ApplyMaterialOffset(Operator):
     bl_label = 'Apply Material Offset'
     bl_description = 'Calculates the offsets and apply them, then the temporary material is removed'
     bl_options = {'PRESET'}
-    
+
+    @classmethod
+    def poll(cls, context):
+        root = mmd_model.Model.findRoot(context.active_object)
+        return root and mmd_model.Model(root).firstMesh()
+
     def execute(self, context):
         obj = context.active_object
         root = mmd_model.Model.findRoot(obj)
         rig = mmd_model.Model(root)
         mmd_root = root.mmd_root
-        meshObj = rig.firstMesh()
         morph = mmd_root.material_morphs[mmd_root.active_morph]
         mat_data = morph.data[morph.active_material_data]
-        # if mmd_root.advanced_mode:
-        relMesh = rig.findMesh(mat_data.related_mesh)
-        if relMesh is not None:
-            meshObj = relMesh
-        else:
-            self.report({ 'ERROR' }, "The related mesh can't be found")
-            return { 'CANCELLED' }
 
+        meshObj = rig.findMesh(mat_data.related_mesh)
         if meshObj is None:
             self.report({ 'ERROR' }, "The model mesh can't be found")
             return { 'CANCELLED' }
-        base_mat = meshObj.data.materials[mat_data.material]
-        work_mat = meshObj.data.materials[base_mat.name+"_temp"]
-        base_idx = meshObj.data.materials.find(base_mat.name)
+        try:
+            work_mat_name = mat_data.material + '_temp'
+            work_mat, base_mat = FnMaterial.swap_materials(meshObj, work_mat_name,
+                                                           mat_data.material)
+        except MaterialNotFoundError:
+            self.report({ 'ERROR' }, "Material not found")
+            return { 'CANCELLED' }
+
         copy_idx = meshObj.data.materials.find(work_mat.name)
         base_mmd_mat = base_mat.mmd_material
         work_mmd_mat = work_mat.mmd_material
-        with bpyutils.select_object(meshObj):
-            for poly in meshObj.data.polygons:
-                if poly.material_index == copy_idx:
-                    poly.material_index = base_idx
+
         if mat_data.offset_type == "MULT":
                 
             try:
@@ -315,12 +315,14 @@ class ApplyMaterialOffset(Operator):
                 mat_data.ambient_color = divide_vector_components(work_mmd_mat.ambient_color, base_mmd_mat.ambient_color)
                 mat_data.edge_color = edge_offset
                 mat_data.edge_weight = special_division(work_mmd_mat.edge_weight, base_mmd_mat.edge_weight)
-            except ValueError as err:
-                if "Invalid Input:" in str(err):
-                    mat_data.offset_type = "ADD" #If there is any 0 division we automatically switch it to type ADD
-                else:
-                    self.report({ 'ERROR' }, 'An unexpected error happened')                          
-                    
+
+            except DivisionError:
+                mat_data.offset_type = "ADD" # If there is any 0 division we automatically switch it to type ADD
+            except ValueError:
+                self.report({ 'ERROR' }, 'An unexpected error happened')
+                # We should stop on our tracks and re-raise the exception
+                raise
+
         if mat_data.offset_type =="ADD":        
             diffuse_offset = list(work_mmd_mat.diffuse_color - base_mmd_mat.diffuse_color) + [work_mmd_mat.alpha - base_mmd_mat.alpha]
             specular_offset = list(work_mmd_mat.specular_color - base_mmd_mat.specular_color)
@@ -342,38 +344,29 @@ class CreateWorkMaterial(Operator):
     bl_label = 'Create Work Material'
     bl_description = 'Creates a temporary material to edit this offset'
     bl_options = {'PRESET'}
-    
+
+    @classmethod
+    def poll(cls, context):
+        root = mmd_model.Model.findRoot(context.active_object)
+        return root and mmd_model.Model(root).firstMesh()
+
     def execute(self, context):
         obj = context.active_object
         root = mmd_model.Model.findRoot(obj)
         rig = mmd_model.Model(root)
         mmd_root = root.mmd_root
-        meshObj = rig.firstMesh()
         morph = mmd_root.material_morphs[mmd_root.active_morph]
         mat_data = morph.data[morph.active_material_data]
 
-        # if mmd_root.advanced_mode:
-        relMesh = rig.findMesh(mat_data.related_mesh)
-        if relMesh is not None:
-            meshObj = relMesh
-        else:
-            self.report({ 'ERROR' }, "The related mesh can't be found")
-            return { 'CANCELLED' }
-
+        meshObj = rig.findMesh(mat_data.related_mesh)
         if meshObj is None:
             self.report({ 'ERROR' }, "The model mesh can't be found")
             return { 'CANCELLED' }
         base_mat = meshObj.data.materials[mat_data.material]
         work_mat = base_mat.copy()
         work_mat.name = base_mat.name+"_temp"     
-        meshObj.data.materials.append(work_mat)   
-        base_idx = meshObj.data.materials.find(base_mat.name)
-        copy_idx = meshObj.data.materials.find(work_mat.name)
-        with bpyutils.select_object(meshObj):
-            for poly in meshObj.data.polygons:
-                if poly.material_index == base_idx:
-                    poly.material_index = copy_idx
-
+        meshObj.data.materials.append(work_mat)
+        FnMaterial.swap_materials(meshObj, base_mat.name, work_mat.name)
         base_mmd_mat = base_mat.mmd_material
         work_mmd_mat = work_mat.mmd_material
 
@@ -405,12 +398,18 @@ class CreateWorkMaterial(Operator):
 
         mmd_root.editing_morphs += 1
         return { 'FINISHED' }
+
 class ClearTempMaterials(Operator):
     bl_idname = 'mmd_tools.clear_temp_materials'
     bl_label = 'Clear Temp Materials'
     bl_description = 'Clears all the temporary materials'
     bl_options = {'PRESET'}
-    
+
+    @classmethod
+    def poll(cls, context):
+        root = mmd_model.Model.findRoot(context.active_object)
+        return root and mmd_model.Model(root).firstMesh()
+
     def execute(self, context):
         obj = context.active_object
         root = mmd_model.Model.findRoot(obj)
@@ -422,18 +421,15 @@ class ClearTempMaterials(Operator):
                     mats_to_delete.append(mat)
             for temp_mat in reversed(mats_to_delete):
                 base_mat_name=temp_mat.name[0:-1*len("_temp")]
-                base_idx = meshObj.data.materials.find(base_mat_name)
-                temp_idx = meshObj.data.materials.find(temp_mat.name)
-                if base_idx == -1:
-                    self.report({ 'ERROR' } ,'Warning! base material for %s was not found'%temp_mat.name)
+                try:
+                    FnMaterial.swap_materials(meshObj, temp_mat.name, base_mat_name)
+                except MaterialNotFoundError:
+                    self.report({ 'WARNING' } ,'Base material for %s was not found'%temp_mat.name)
                 else:
-                    with bpyutils.select_object(meshObj):
-                        for poly in meshObj.data.polygons:
-                            if poly.material_index == temp_idx:
-                                poly.material_index = base_idx
-                        mat = meshObj.data.materials.pop(index=temp_idx)
-                        bpy.data.materials.remove(mat)
-                        root.mmd_root.editing_morphs -= 1
+                    temp_idx = meshObj.data.materials.find(temp_mat.name)
+                    mat = meshObj.data.materials.pop(index=temp_idx)
+                    bpy.data.materials.remove(mat)
+                    root.mmd_root.editing_morphs -= 1
 
         return { 'FINISHED' }
     

--- a/mmd_tools/panels/__init__.py
+++ b/mmd_tools/panels/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from . import prop_bone, prop_camera, prop_material, prop_object, tool, view_prop
+from . import prop_bone, prop_camera, prop_material, prop_object, tool, view_prop, util_tools

--- a/mmd_tools/panels/util_tools.py
+++ b/mmd_tools/panels/util_tools.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from bpy.types import Panel, UIList
+
+from mmd_tools.core.model import Model
+
+class _PanelBase(object):
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'TOOLS'
+    bl_category = 'mmd_utils'
+
+class UL_Materials(UIList):
+
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        if self.layout_type in {'DEFAULT'}:    
+            if item:        
+                layout.label(text=item.name, translate=False, icon='MATERIAL')
+            else:
+                layout.label(text='UNSET', translate=False, icon='ERROR')
+        elif self.layout_type in {'COMPACT'}:
+            pass
+        elif self.layout_type in {'GRID'}:
+            layout.alignment = 'CENTER'
+            layout.label(text="", icon_value=icon)
+
+    def draw_filter(self, context, layout):
+        layout.label(text="Use the arrows to sort", icon='INFO')
+
+class MMDMaterialSorter(_PanelBase, Panel):
+    bl_idname = 'OBJECT_PT_mmd_tools_material_sorter'
+    bl_label = 'Material Sorter'
+    bl_context = ''
+
+    def draw(self, context):
+        layout = self.layout
+        active_obj = context.active_object
+        if (active_obj is None or active_obj.type != 'MESH' or
+            active_obj.mmd_type != 'NONE'):
+            layout.label("Select a mesh object")
+            return
+
+        col = layout.column(align=True)
+        row = col.row()
+        row.template_list("UL_Materials", "",
+                          active_obj.data, "materials",
+                          active_obj, "active_material_index")
+        tb = row.column()
+        tbl = tb.column(align=True)
+        tbl.operator('mmd_tools.move_material_up', text='', icon='TRIA_UP')
+        tbl.operator('mmd_tools.move_material_down', text='', icon='TRIA_DOWN')

--- a/mmd_tools/panels/util_tools.py
+++ b/mmd_tools/panels/util_tools.py
@@ -48,3 +48,61 @@ class MMDMaterialSorter(_PanelBase, Panel):
         tbl = tb.column(align=True)
         tbl.operator('mmd_tools.move_material_up', text='', icon='TRIA_UP')
         tbl.operator('mmd_tools.move_material_down', text='', icon='TRIA_DOWN')
+
+class UL_ModelMeshes(UIList):
+
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        if self.layout_type in {'DEFAULT'}:           
+            layout.label(text=item.name, translate=False, icon='OBJECT_DATA')
+        elif self.layout_type in {'COMPACT'}:
+            pass
+        elif self.layout_type in {'GRID'}:
+            layout.alignment = 'CENTER'
+            layout.label(text="", icon_value=icon)
+
+    def draw_filter(self, context, layout):
+        layout.label(text="Use the arrows to sort", icon='INFO')
+
+    def filter_items(self, context, data, propname):
+        # We will use the filtering to sort the mesh objects to match the rig order
+        objects = getattr(data, propname)
+        flt_flags = [~self.bitflag_filter_item] * len(objects)
+        flt_neworder = list(range(len(objects)))
+        active_root = Model.findRoot(context.active_object)
+        rig = Model(active_root)
+        for i, obj in enumerate(objects):
+            if (obj.type == 'MESH' and obj.mmd_type == 'NONE'
+                    and Model.findRoot(obj) == active_root):
+                flt_flags[i] = self.bitflag_filter_item 
+                new_index = rig.getMeshIndex(obj.name)
+                flt_neworder[i] = new_index
+
+        return flt_flags, flt_neworder
+                
+
+class MMDMeshSorter(_PanelBase, Panel):
+    bl_idname = 'OBJECT_PT_mmd_tools_meshes_sorter'
+    bl_label = 'Meshes Sorter'
+    bl_context = ''
+
+    def draw(self, context):
+        layout = self.layout
+        active_obj = context.active_object
+        root = Model.findRoot(active_obj)
+        if root is None:
+            layout.label("Select a MMD Model")
+            return
+        rig = Model(root)
+        if rig.firstMesh() is None:
+            layout.label("This model don't have meshes")
+            return
+
+        col = layout.column(align=True)
+        row = col.row()
+        row.template_list("UL_ModelMeshes", "",
+                          context.scene, "objects",
+                          root.mmd_root, "active_mesh_index")
+        tb = row.column()
+        tbl = tb.column(align=True)
+        tbl.operator('mmd_tools.move_mesh_up', text='', icon='TRIA_UP')
+        tbl.operator('mmd_tools.move_mesh_down', text='', icon='TRIA_DOWN')

--- a/mmd_tools/properties/root.py
+++ b/mmd_tools/properties/root.py
@@ -129,8 +129,21 @@ def _getActiveJointObject(prop):
 def _activeMorphReset(self, context):
     root = self.id_data
     root.mmd_root.active_morph = 0
-    
 
+def _setActiveMeshObject(prop, v):
+    obj = bpy.context.scene.objects[v]
+    if obj.type == 'MESH' and obj.mmd_type == 'NONE':
+        obj.hide = False
+        utils.selectAObject(obj)
+    prop['active_mesh_index'] = v
+    
+def _getActiveMeshObject(prop):
+    objects = bpy.context.scene.objects
+    active_obj = objects.active
+    if (active_obj and active_obj.type == 'MESH'
+            and active_obj.mmd_type == 'NONE'):
+        prop['active_mesh_index'] = objects.find(active_obj.name)
+    return prop.get('active_mesh_index', -1)
 
 #===========================================
 # Property classes
@@ -356,4 +369,11 @@ class MMDRoot(PropertyGroup):
                      'This is used as safety check to prevent some operations.'),
         default=0, 
         min=0,
+        )
+    active_mesh_index = IntProperty(
+        name='Active Mesh',
+        description='Active Mesh in this model',
+        default=-1,
+        set=_setActiveMeshObject,
+        get=_getActiveMeshObject,
         )

--- a/mmd_tools/utils.py
+++ b/mmd_tools/utils.py
@@ -150,3 +150,23 @@ def uniqueName(name, used_names):
         count += 1
     return new_name
 
+def int2base(x, base):
+    """
+    Method to convert an int to a base
+    Source: http://stackoverflow.com/questions/2267362
+    """
+    import string
+    digs = string.digits + string.ascii_uppercase
+    if x < 0: sign = -1
+    elif x == 0: return digs[0]
+    else: 
+        sign = 1
+        x *= sign
+        digits = []
+    while x:
+        digits.append(digs[x % base])
+        x = int(x / base)
+    if sign < 0:
+        digits.append('-')
+    digits.reverse()
+    return ''.join(digits)


### PR DESCRIPTION
Finally I have finished the implementation of the material and mesh sorters. For the materials was pretty easy, for the meshes I used a prefix as I mentioned earlier and was pretty easy too except for a few issues that I had when dealing with conversions of integer to base 36. With this implementation the 3-character prefix can handle up to `int('ZZZ', 36) + 1` meshes, which is exactly 46656. That should be enough.

About the UI. I decided to place these panel on another tab for these reasons:
- The main `mmd_tools` tab is already a bit overloaded
- I wanted to separate the "main" tools, which will be needed in most use cases from the "extra" tools, which may be not necessary on a general basis.
- I plan to include more panels there. For example I would like to emulate the PMX Editor plugin called "SemiStandardBones", which automate the creation of some of the so-called semi standard bones, such as 上半身2 (upper_body2). A panel with that utilities would be awesome.

However, instead of having 2 panels for the sorter we could have them in a single one, called for example "Sorting Tools".
As you said before, it is very easy to change, thanks to a good code structure which allows us to change the UI  code without affecting the business logic.

I let that decision to you, change the UI as you like. It took time code those panels, so I am not willing to change it right now because it would be troublesome ![what a drag](http://orig09.deviantart.net/035e/f/2015/046/2/4/shikamaru_mendokusai_by_harryhack91-d8i2z3c.png)
