### PR TITLE
Improved Copy Textures feature and some fixes

### DIFF
--- a/mmd_tools/utils.py
+++ b/mmd_tools/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
-import math
+import os
 
 ## 指定したオブジェクトのみを選択状態かつアクティブにする
 def selectAObject(obj):
@@ -170,3 +170,31 @@ def int2base(x, base):
         digits.append('-')
     digits.reverse()
     return ''.join(digits)
+
+def saferelpath(path, start, strategy='inside'):
+    """
+    On Windows relpath will raise a ValueError
+    when trying to calculate the relative path to a
+    different drive.
+    This method will behave different depending on the strategy
+    choosen to handle the different drive issue.
+    Strategies:
+    - inside: this will just return the basename of the path given
+    - outside: this will prepend '..' to the basename
+    - absolute: this will return the absolute path instead of a relative.
+    See http://bugs.python.org/issue7195
+    """
+    result = os.path.basename(path)
+    if os.name == 'nt':
+        d1 = os.path.splitdrive(path)[0]
+        d2 = os.path.splitdrive(start)[0]
+        if d1 != d2:
+            if strategy == 'outside':
+                result = '..'+os.sep+os.path.basename(path)
+            elif strategy == 'absolute':
+                result = os.path.abspath(path)
+        else:
+            result = os.path.relpath(path, start)
+    else:
+        result = os.path.relpath(path, start)
+    return result


### PR DESCRIPTION
Finally I had time to test the copy textures feature. So far it was working good. When you import a model the model's import folder takes precedence and it is used to determine the relative paths. If you create a model from scratch and have configured a `base_texture_folder` preference that will be used instead. There was just one limitation, you couldn't mix both. That's why I improved the method to handle both directories. First it checks if the texture is on the import folder and then if it is on the base_texture_folder.

I've also fixed some bugs that I found:
- Adding a new mesh (same object) to an imported model caused a problem during export because of the `vg_edge_scale`. That's because the vertexes of the new mesh will not be in the group and calling the `weight` method will raise an error.
- On Windows `os.path.relpath` will raise an error when the path and the start are in different drives. See http://bugs.python.org/issue7195

PD: By the way. I think you should set `dev_test` as your main branch in the repository settings, at least until @sugiany comes back. That will make it easier for pull requests because the main branch is always selected by default I think.
