### PR TITLE
Fix a bug in cycles converter on non-english locale

### DIFF
--- a/mmd_tools/cycles_converter.py
+++ b/mmd_tools/cycles_converter.py
@@ -16,6 +16,15 @@ def __exposeNodeTreeOutput(out_socket, name, node_output, shader):
     shader.links.new(i, out_socket)
     shader.outputs[t].name = name
 
+def __getMaterialOutput(nodes):
+    for node in nodes:
+        if isinstance(node, bpy.types.ShaderNodeOutputMaterial):
+            return node
+
+    o = nodes.new('ShaderNodeOutputMaterial')
+    o.name = 'Material Output'
+    return o
+
 def create_MMDAlphaShader():
     bpy.context.scene.render.engine = 'CYCLES'
 
@@ -140,9 +149,7 @@ def convertToCyclesShader(obj):
             if i.material.alpha < 1.0:
                 alpha_shader.inputs[1].default_value = i.material.alpha
 
-        if 'Material Output' not in i.material.node_tree.nodes:
-            o = i.material.node_tree.nodes.new('ShaderNodeOutputMaterial')
-            o.name = 'Material Output'
-        i.material.node_tree.links.new(i.material.node_tree.nodes['Material Output'].inputs['Surface'], outplug)
-        i.material.node_tree.nodes['Material Output'].location.x = shader.location.x + 500
-        i.material.node_tree.nodes['Material Output'].location.y = shader.location.y - 150
+        material_output = __getMaterialOutput(i.material.node_tree.nodes)
+        i.material.node_tree.links.new(material_output.inputs['Surface'], outplug)
+        material_output.location.x = shader.location.x + 500
+        material_output.location.y = shader.location.y - 150


### PR DESCRIPTION
In japanese environment, cycles converter fails to convert materials.
![cycles_bug](https://cloud.githubusercontent.com/assets/287255/19021865/af478f44-8905-11e6-9edf-31a68552fd68.png)
After converting materials, material output node is duplicated and all materials are black.
bacase, in japanese environment, the name of the matrial output node is  'マテリアル出力', it's not 'Matrial Output'.
This PR fixes the above issue.
