### PR TITLE
Make ImportPmx undo compatible

### DIFF
--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -64,7 +64,7 @@ class ImportPmx(Operator, ImportHelper):
     bl_idname = 'mmd_tools.import_model'
     bl_label = 'Import Model file (.pmd, .pmx)'
     bl_description = 'Import Model file(s) (.pmd, .pmx)'
-    bl_options = {'PRESET'}
+    bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     files = bpy.props.CollectionProperty(type=OperatorFileListElement, options={'HIDDEN', 'SKIP_SAVE'})
     directory = bpy.props.StringProperty(maxlen=1024, subtype='FILE_PATH', options={'HIDDEN', 'SKIP_SAVE'})


### PR DESCRIPTION
This helps undoing operations after the import. Because currently undoing the operation after the import undos the import as well. This small change creates an undo point after the import is finished.
You might want to add 'REGISTER' and 'UNDO' to every bl_options in order to make every command undoable.