### PR TITLE
Fix bone direction of tip bone with fixed axis

### DIFF
--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -263,8 +263,19 @@ class PMXImporter:
             for b_bone, m_bone in zip(editBoneTable, pmx_bones):
                 # Set the length of too short bones to 1 because Blender delete them.
                 if b_bone.length < 0.001:
-                    loc = mathutils.Vector([0, 0, 1]) * self.__scale
-                    b_bone.tail = b_bone.head + loc
+                    if m_bone.axis is not None:
+                        bone_loc = mathutils.Vector(m_bone.location)
+                        fixed_axis = mathutils.Vector(m_bone.axis).normalized()
+                        bone_dir = ((bone_loc + fixed_axis - bone_loc) * self.TO_BLE_MATRIX).normalized()
+                        if bone_dir.length > 0.0:
+                            loc = bone_dir * self.__scale
+                            b_bone.tail = b_bone.head + loc
+                        else:
+                            loc = mathutils.Vector([0, 0, 1]) * self.__scale
+                            b_bone.tail = b_bone.head + loc
+                    else:
+                        loc = mathutils.Vector([0, 0, 1]) * self.__scale
+                        b_bone.tail = b_bone.head + loc
                     if m_bone.displayConnection != -1 and m_bone.displayConnection != [0.0, 0.0, 0.0]:
                         logging.debug(' * special tip bone %s, display %s', b_bone.name, str(m_bone.displayConnection))
                         specialTipBones.append(b_bone.name)
@@ -443,10 +454,10 @@ class PMXImporter:
                 mmd_bone.enabled_fixed_axis = True
                 mmd_bone.fixed_axis = pmx_bone.axis
 
-            #if mmd_bone.is_tip:
-            #    b_bone.lock_rotation = [True, True, True]
-            #    b_bone.lock_location = [True, True, True]
-            #    b_bone.lock_scale = [True, True, True]
+                if mmd_bone.is_tip:
+                    b_bone.lock_rotation = [True, False, True]
+                    b_bone.lock_location = [True, True, True]
+                    b_bone.lock_scale = [True, True, True]
 
     def __importRigids(self):
         start_time = time.time()


### PR DESCRIPTION
Arm twist bones without local coordinate property can not rotate properly in pose mode due to the bone direction.
This PR fixes the above issue and supports tip bone with fixed_axis property of pmx.

current (model MikuMikuDance_v931\UserFile\Mode\初音ミクVer2.pmd)
![0cffa5c3cf5d4afe0cc5cfb0021f90d7](https://user-images.githubusercontent.com/287255/41371206-9d293544-6f84-11e8-80cf-62daa4f79194.png)

fixed
![8c2d376efac1e50a482436da7c0fa442](https://user-images.githubusercontent.com/287255/41371224-a86485b2-6f84-11e8-82a9-0ed2cedc2976.png)


I have tested with some models and motions that using arm twist bones, and motion exporting, but it may not be enough. could you review?

Also, MMD seems to have the function to automatically set the bone roll of arm related bones which does not have the local coordinate property. I am planning to send PR for it as well.