### PR TITLE
Add support for automatically setting the bone roll for arm related bones

### DIFF
--- a/mmd_tools/core/bone.py
+++ b/mmd_tools/core/bone.py
@@ -130,12 +130,15 @@ class FnBone(object):
 
     @classmethod
     def update_auto_bone_roll(cls, edit_bone):
-        y_axis = (edit_bone.tail - edit_bone.head)
-        head_y_aligned = Vector((edit_bone.head.x, edit_bone.tail.y, edit_bone.head.z))
-        y_axis_fix = (edit_bone.tail - head_y_aligned)
-        rot = Quaternion(y_axis_fix).rotation_difference(Quaternion(y_axis))
-        mmd_x_axis = y_axis.normalized().xzy
-        mmd_z_axis = Vector((Quaternion((0, -1, 0)) * rot).to_euler()).normalized().xzy
+        loc = edit_bone.matrix.to_translation()
+        mmd_x_axis = edit_bone.vector.normalized().xzy
+        mmd_y_axis = mmd_x_axis.copy()
+        if loc.x > 0: # left arm
+            mmd_y_axis.x = -mmd_y_axis.x
+            mmd_y_axis.z = -mmd_y_axis.z # <- fix axis issue
+        else:
+            mmd_y_axis.y = -mmd_y_axis.y
+        mmd_z_axis = mmd_x_axis.cross(mmd_y_axis).normalized()
         cls.update_bone_roll(edit_bone, mmd_x_axis, mmd_z_axis)
 
     @classmethod

--- a/mmd_tools/core/bone.py
+++ b/mmd_tools/core/bone.py
@@ -4,7 +4,7 @@ import bpy
 from bpy.types import PoseBone
 
 from math import pi
-from mathutils import Vector
+from mathutils import Vector, Quaternion
 from mmd_tools import bpyutils
 from mmd_tools.bpyutils import TransformConstraintOp
 
@@ -130,14 +130,12 @@ class FnBone(object):
 
     @classmethod
     def update_auto_bone_roll(cls, edit_bone):
-        loc = edit_bone.matrix.to_translation()
-        mmd_x_axis = edit_bone.vector.normalized().xzy
-        mmd_y_axis = mmd_x_axis.copy()
-        if loc.x > 0: # left arm
-            mmd_y_axis.x = -mmd_y_axis.x
-        else:
-            mmd_y_axis.y = -mmd_y_axis.y
-        mmd_z_axis = mmd_x_axis.cross(mmd_y_axis).normalized()
+        y_axis = (edit_bone.tail - edit_bone.head)
+        head_y_aligned = Vector((edit_bone.head.x, edit_bone.tail.y, edit_bone.head.z))
+        y_axis_fix = (edit_bone.tail - head_y_aligned)
+        rot = Quaternion(y_axis_fix).rotation_difference(Quaternion(y_axis))
+        mmd_x_axis = y_axis.normalized().xzy
+        mmd_z_axis = Vector((Quaternion((0, -1, 0)) * rot).to_euler()).normalized().xzy
         cls.update_bone_roll(edit_bone, mmd_x_axis, mmd_z_axis)
 
     @classmethod

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -283,6 +283,8 @@ class PMXImporter:
             for b_bone, m_bone in zip(editBoneTable, pmx_bones):
                 if m_bone.localCoordinate is not None:
                     FnBone.update_bone_roll(b_bone, m_bone.localCoordinate.x_axis, m_bone.localCoordinate.z_axis)
+                elif FnBone.has_auto_local_axis(m_bone.name):
+                    FnBone.update_auto_bone_roll(b_bone)
 
         return nameTable, specialTipBones
 

--- a/mmd_tools/operators/misc.py
+++ b/mmd_tools/operators/misc.py
@@ -10,6 +10,7 @@ from mmd_tools.bpyutils import ObjectOp
 from mmd_tools.core import model as mmd_model
 from mmd_tools.core.morph import FnMorph
 from mmd_tools.core.material import FnMaterial
+from mmd_tools.core.bone import FnBone
 
 
 class MoveObject(Operator, utils.ItemMoveOp):
@@ -297,3 +298,29 @@ class ChangeMMDIKLoopFactor(Operator):
                 c.iterations = iterations
         return { 'FINISHED' }
 
+class RecalculateBoneRoll(Operator):
+    bl_idname = 'mmd_tools.recalculate_bone_roll'
+    bl_label = 'Recalculate bone roll'
+    bl_description = 'Recalculate bone roll for arm related bones'
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.active_object
+        return obj and obj.type == 'ARMATURE'
+
+    def invoke(self, context, event):
+        arm = context.active_object
+        vm = context.window_manager
+        return vm.invoke_props_dialog(self)
+
+    def draw(self, context):
+        layout = self.layout
+        c = layout.column()
+        c.label(text='This operation will break existing f-curve/action.', icon='QUESTION')
+        c.label(text='Click [OK] to run the operation.')
+
+    def execute(self, context):
+        arm = context.active_object
+        FnBone.apply_auto_bone_roll(arm)
+        return { 'FINISHED' }

--- a/mmd_tools/operators/view.py
+++ b/mmd_tools/operators/view.py
@@ -148,8 +148,7 @@ class FlipPose(Operator):
     def poll(cls, context):
         return (context.active_object and
                     context.active_object.type == 'ARMATURE' and
-                    context.active_object.mode == 'POSE' and
-                    getattr(context.active_object, 'mmd_root', None) is not None)
+                    context.active_object.mode == 'POSE')
 
     def execute(self, context):
         copy_buffer = []

--- a/mmd_tools/operators/view.py
+++ b/mmd_tools/operators/view.py
@@ -2,7 +2,8 @@
 
 import bpy
 from bpy.types import Operator
-
+from mathutils import Matrix
+import re
 
 class SetGLSLShading(Operator):
     bl_idname = 'mmd_tools.set_glsl_shading'
@@ -79,4 +80,102 @@ class ResetShading(Operator):
         context.area.spaces[0].viewport_shade='SOLID'
         context.area.spaces[0].show_backface_culling = True
         bpy.context.scene.game_settings.material_mode = 'MULTITEXTURE'
+        return {'FINISHED'}
+
+class FlipPose(Operator):
+    bl_idname = 'mmd_tools.flip_pose'
+    bl_label = 'Flip Pose'
+    bl_description = 'Apply the current pose of selected bones to matching bone on opposite side of X-Axis.'
+    bl_options = {'REGISTER', 'UNDO'}
+
+    # https://docs.blender.org/manual/en/dev/rigging/armatures/bones/editing/naming.html
+    __LR_REGEX = [
+        {"re": re.compile(r'^(.+)(RIGHT|LEFT)(\.\d+)?$', re.IGNORECASE), "lr": 1},
+        {"re": re.compile(r'^(.+)([\.\- _])(L|R)(\.\d+)?$', re.IGNORECASE), "lr": 2},
+        {"re": re.compile(r'^(LEFT|RIGHT)(.+)$', re.IGNORECASE), "lr": 0},
+        {"re": re.compile(r'^(L|R)([\.\- _])(.+)$', re.IGNORECASE), "lr": 0}
+    ]
+    __LR_MAP = {
+        "RIGHT": "LEFT",
+        "Right": "Left",
+        "right": "left",
+        "LEFT": "RIGHT",
+        "Left": "Right",
+        "left": "right",
+        "L": "R",
+        "l": "r",
+        "R": "L",
+        "r": "l"
+    }
+    @classmethod
+    def __flip_name(cls, name):
+        for regex in cls.__LR_REGEX:
+            match = regex["re"].match(name)
+            if match:
+                groups = match.groups()
+                lr = groups[regex["lr"]]
+                if lr in cls.__LR_MAP:
+                    flip_lr = cls.__LR_MAP[lr]
+                    name = ''
+                    for i, s in enumerate(groups):
+                        if i == regex["lr"]:
+                            name += flip_lr
+                        elif s:
+                            name += s
+                    return name
+        return None
+
+    @staticmethod
+    def __cmul(vec1, vec2):
+        return type(vec1)([x * y for x, y in zip(vec1, vec2)])
+
+    @staticmethod
+    def __matrix_compose(loc, rot, scale):
+        return (Matrix.Translation(loc) *
+                rot.to_matrix().to_4x4() *
+                Matrix.Scale(scale[0], 4, (1, 0, 0)) *
+                Matrix.Scale(scale[1], 4, (0, 1, 0)) *
+                Matrix.Scale(scale[2], 4, (0, 0, 1)))
+
+    @classmethod
+    def __flip_direction(cls, bone1, bone2):
+        axis1 = bone1.matrix_local.to_3x3().transposed()
+        axis2 = bone2.matrix_local.to_3x3().transposed()
+        axis1 = [cls.__cmul(vec, (-1, 1, 1)) for vec in axis1]
+        return [1] + [(1, -1)[vec1.dot(vec2) > 0] for vec1, vec2 in zip(axis1, axis2)]
+
+    @classmethod
+    def poll(cls, context):
+        return (context.active_object and
+                    context.active_object.type == 'ARMATURE' and
+                    context.active_object.mode == 'POSE' and
+                    getattr(context.active_object, 'mmd_root', None) is not None)
+
+    def execute(self, context):
+        copy_buffer = []
+        arm = context.active_object
+
+        for pose_bone in context.selected_pose_bones:
+            print(pose_bone.bone.name, self.__flip_name(pose_bone.bone.name))
+            copy_buffer.append({
+                'name': pose_bone.bone.name,
+                'flipped_name': self.__flip_name(pose_bone.bone.name),
+                'bone': pose_bone.bone,
+                'matrix_basis': pose_bone.matrix_basis.copy()})
+
+        for b in copy_buffer:
+            if b["flipped_name"] and b["flipped_name"] in arm.pose.bones:
+                pose_bone = arm.pose.bones[b["flipped_name"]]
+                sign = self.__flip_direction(b['bone'], pose_bone.bone)
+                loc, rot, scale = b['matrix_basis'].decompose()
+                loc = self.__cmul(loc, (-1, 1, 1))
+                rot = self.__cmul(rot, sign)
+                pose_bone.matrix_basis = self.__matrix_compose(loc, rot, scale)
+            else:
+                pose_bone = arm.pose.bones[b['name']]
+                loc, rot, scale = b['matrix_basis'].decompose()
+                loc = self.__cmul(loc, (-1, 1, 1))
+                rot = self.__cmul(rot, (1, 1, -1, -1))
+                pose_bone.matrix_basis = self.__matrix_compose(loc, rot, scale)
+
         return {'FINISHED'}

--- a/mmd_tools/operators/view.py
+++ b/mmd_tools/operators/view.py
@@ -156,7 +156,6 @@ class FlipPose(Operator):
         arm = context.active_object
 
         for pose_bone in context.selected_pose_bones:
-            print(pose_bone.bone.name, self.__flip_name(pose_bone.bone.name))
             copy_buffer.append({
                 'name': pose_bone.bone.name,
                 'flipped_name': self.__flip_name(pose_bone.bone.name),

--- a/mmd_tools/panels/__init__.py
+++ b/mmd_tools/panels/__init__.py
@@ -13,6 +13,7 @@ if "bpy" in locals():
     importlib.reload(tool)
     importlib.reload(util_tools)
     importlib.reload(view_prop)
+    importlib.reload(view_header)
 else:
     import bpy
     from . import (
@@ -24,5 +25,6 @@ else:
         tool,
         util_tools,
         view_prop,
+        view_header
         )
 

--- a/mmd_tools/panels/prop_object.py
+++ b/mmd_tools/panels/prop_object.py
@@ -34,7 +34,7 @@ class MMDModelObjectPanel(_PanelBase, Panel):
         c.prop_search(root.mmd_root, 'comment_e_text', search_data=bpy.data, search_property='texts')
         c = layout.column()
         c.operator('mmd_tools.change_mmd_ik_loop_factor', text='Change MMD IK Loop Factor')
-
+        c.operator('mmd_tools.recalculate_bone_roll', text='Recalculate bone roll')
 
 class MMDRigidPanel(_PanelBase, Panel):
     bl_idname = 'RIGID_PT_mmd_tools_bone'

--- a/mmd_tools/panels/view_header.py
+++ b/mmd_tools/panels/view_header.py
@@ -9,8 +9,7 @@ class MMDViewHeader(Header):
     def poll(cls, context):
         return (context.active_object and
                 context.active_object.type == 'ARMATURE' and
-                context.active_object.mode == 'POSE' and
-                getattr(context.active_object, 'mmd_root', None) is not None)
+                context.active_object.mode == 'POSE')
 
     def draw(self, context):
         if self.poll(context):

--- a/mmd_tools/panels/view_header.py
+++ b/mmd_tools/panels/view_header.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from bpy.types import Header
+
+class MMDViewHeader(Header):
+    bl_space_type = 'VIEW_3D'
+
+    @classmethod
+    def poll(cls, context):
+        return (context.active_object and
+                context.active_object.type == 'ARMATURE' and
+                context.active_object.mode == 'POSE' and
+                getattr(context.active_object, 'mmd_root', None) is not None)
+
+    def draw(self, context):
+        if self.poll(context):
+            self.layout.operator('mmd_tools.flip_pose', text='', icon='ARROW_LEFTRIGHT')


### PR DESCRIPTION
_Sorry for the long description, and my poor English :(_

This PR contains the following changes. These are related to each other.
- Support automatically setting the bone roll for arm related bones in PMX Importer
- Add Flip pose operator for mmd_tools
- Add Recalculate bone roll operator for existing imported models

### (1) Automatically setting the bone roll for arm related bones in PMX Importer

#### Issue
Since the current mmd_tools does not set the bone roll of arm or finger bones, so it is misaligned. It is difficult to rotate fingers, and it is also difficult to use Graph Editor.

![62262ccd6ed5539268483fdae82eb8b3](https://user-images.githubusercontent.com/287255/41613018-68efadee-742f-11e8-819a-dc01c4ea7fb9.png)

#### Investigation
MMD has the feature to automatically set the bone roll(local axis) for arm related bones. It is pointed out in PMX specification document.

>※PMDでは腕関連のみ子ボーンの方向をX、手前を-Zとする軸でローカルフレームが自動作成される模様。
>In PMD, it seems that the local frame is automatically created for the arm-related bones. The direction to the child bone is X, the direction towards you is -Z.

Also, the same feature can be seen in MMDAI's source code. (`Bone::hasLocalAxes` and `Bone::getLocalAxes`)
https://github.com/hkrn/MMDAI/blob/9ca74bf9f6f979f510f5355d80805f935cc7e610/libvpvl2/src/core/pmd2/Bone.cc#L455-L492
More details are described on the following blog post. (Japanese)
http://ch.nicovideo.jp/mea/blomaga/ar231383

The conditions under which the bone roll is automatically set are as follows.
- If the bone name matches 左腕,左ひじ,左手首,右腕,右ひじ,右手首
- If the bone name includes 親指,人指,中指,薬指,子指

I also investigated PMX plugins which automatically set local axes, some plugins also support semi-standard bones (arm twist bones).

#### Implementation
So I implemented this feature in PMX Impoter, it will change the bone roll but not local axis property.
The bone roll (and local axis) is the same as when importing a MMD model with the proper local axis (It is compatible with existing features).

![f88fd9c84fff5e173020bd0d5cc1dd21](https://user-images.githubusercontent.com/287255/41613383-61d7399a-7430-11e8-82a0-a9d934dc0225.png)

### (2) Flip pose operator for mmd_tools

#### Issue
The bone roll when importing a MMD model with the local axis set (also set by the above change), it seems not to be Blender friendly, because Blender's `bpy.ops.pose.paste (flipped=True)` does not work properly.

![051a18e150653b3279d753a6f41c4430](https://user-images.githubusercontent.com/287255/41613675-379027b8-7431-11e8-81a5-19c34b93e931.png)

Also, `bpy.ops.pose.paste(flipped=True)` has a problem of copying `mmd_bone` property to the opposite side #20.

#### Implementation
So I implemented the flip pose operator for mmd_tools, which works properly with any bone roll. The button for the operator will be displayed in 3D View bottom header when Pose Mode and a MMD model's armature is selected.

![b1b83e2f6889cc6a5db07011da72f9ba](https://user-images.githubusercontent.com/287255/41613743-6f4a72bc-7431-11e8-85f7-92ec1c2cfad9.png)
![bc4530ec22467ee909b591bacb1fed17](https://user-images.githubusercontent.com/287255/41613816-a8d3c3f8-7431-11e8-924c-244a50ed742f.png)

The operator works as follows.
- When you selected a bone on one side and run, the pose is applied to matching bone on opposite side of X-Axis
- When you selected bones on both side and run, the pose is flipped on X-Axis.
- Of course, this operator does not break `mmd_bone` property

### (3) Recalculate bone roll operator for existing imported models
This is the operator for applying (1) to existing imported MMD models.
Note that if model has f-curve(action), changing the bone roll will break f-curve. So the warning message will be displayed before running.

The button to run the operator is placed under `Change IK Loop Factor` button on MMD Model Information Tab.

Thanks.
