### PR TITLE
Add support for shoulder bones in apply_auto_bone_roll()

### DIFF
--- a/mmd_tools/core/bone.py
+++ b/mmd_tools/core/bone.py
@@ -25,9 +25,9 @@ def remove_edit_bones(edit_bones, bone_names):
 
 
 class FnBone(object):
-    AUTO_LOCAL_AXIS_ARMS = ('左腕', '左ひじ', '左手首', '右腕', '右ひじ', '右手首')
+    AUTO_LOCAL_AXIS_ARMS = ('左肩', '左腕', '左ひじ', '左手首', '右腕', '右肩', '右ひじ', '右手首')
     AUTO_LOCAL_AXIS_FINGERS = ('親指','人指', '中指', '薬指','小指')
-    AUTO_LOCAL_AXIS_SEMI_STANDARD_ARMS = ('左腕捩', '左手捩', '左ダミー', '右腕捩', '右手捩', '右ダミー')
+    AUTO_LOCAL_AXIS_SEMI_STANDARD_ARMS = ('左腕捩', '左手捩', '左肩P', '左ダミー', '右腕捩', '右手捩', '右肩P', '右ダミー')
 
     def __init__(self, pose_bone=None):
         if pose_bone is not None and not isinstance(pose_bone, PoseBone):


### PR DESCRIPTION
This PR adds shoulder bones to the support list of apply_auto_bone_roll().

In my last PR it does not support shoulder bones, because the blog post I referred to does not mention to the shoulder bone. MMD seems to rotate the shoulder bone on global axis even if local axis rotation mode is specified.
But yesterday I noticed that [MikuMikuMoving](https://sites.google.com/site/mikumikumovingeng/) apply the feature to the shoulder bone, and it works in the same way as local axis rotation on Blender.

