### PR TITLE
Minor update for Blender 2.8

### DIFF
--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -998,7 +998,8 @@ class __PmxExporter:
         else:
             def _to_mesh(obj):
                 bpy.context.view_layer.update()
-                return obj.evaluated_get(bpy.context.evaluated_depsgraph_get()).to_mesh()
+                depsgraph = bpy.context.evaluated_depsgraph_get()
+                return obj.evaluated_get(depsgraph).to_mesh(depsgraph=depsgraph, preserve_all_data_layers=True)
             _to_mesh_clear = lambda obj, mesh: obj.to_mesh_clear()
 
         base_mesh = _to_mesh(meshObj)


### PR DESCRIPTION
_This PR does not need to be merged immediately._

When a mesh has modifiers (e.g. Bevel modifier), vertex weights are not exported correctly.
The mesh returned from `obj.evaluated_get(bpy.context.evaluated_depsgraph_get()).to_mesh()` seems to have lost vertex groups when the mesh has modifiers.

related: https://developer.blender.org/T65544 https://developer.blender.org/rB5dbda33462349a4ac78f08e8ed4ec7922ca7394f

I am not very confident about this change, but it seems to work in latest master branch of Blender.