### PR TITLE
Fix an issue with SDEF driver for Blender 2.8 (#238)

### DIFF
--- a/mmd_tools/core/sdef.py
+++ b/mmd_tools/core/sdef.py
@@ -223,6 +223,9 @@ class FnSDEF():
         cls.register_driver_function()
         if bulk_update is None:
             bulk_update = cls.__get_benchmark_result(obj, shapekey, use_scale, use_skip)
+        # FIXME: force disable use_skip=True for bulk_update=False on 2.8
+        if bpy.app.version >= (2, 80, 0) and (not bulk_update and use_skip):
+            use_skip = False
         # Add the driver to the shapekey
         f = obj.data.shape_keys.driver_add('key_blocks["'+cls.SHAPEKEY_NAME+'"].value', -1)
         if hasattr(f.driver, 'show_debug_info'):
@@ -233,6 +236,13 @@ class FnSDEF():
         ov.type = 'SINGLE_PROP'
         ov.targets[0].id = obj
         ov.targets[0].data_path = 'name'
+        mod = obj.modifiers.get('mmd_bone_order_override')
+        if mod and mod.type == 'ARMATURE':
+            ov = f.driver.variables.new()
+            ov.name = 'arm'
+            ov.type = 'SINGLE_PROP'
+            ov.targets[0].id = mod.object
+            ov.targets[0].data_path = 'name'
         if hasattr(f.driver, 'use_self'): # Blender 2.78+
             f.driver.use_self = True
             param = (bulk_update, use_skip, use_scale)


### PR DESCRIPTION
#238 
### driver issue
SDEF driver is not linked to the armature, so the driver function is not called from bone deformation.
I added a dummy variable referencing the armature to the driver.

### normal mode and skip=True does not work on 2.8
I don't know why. Maybe related to depsgraph.
If bulk_update == False, force skip = False for 2.8.
