### PR TITLE
Update for Mapping node changes of Blender 2.81

### DIFF
--- a/mmd_tools/core/material.py
+++ b/mmd_tools/core/material.py
@@ -647,8 +647,12 @@ class _FnMaterialCycles(_FnMaterialBI):
 
         node_vector = __new_node('ShaderNodeMapping', (2, -1))
         node_vector.vector_type = 'POINT'
-        node_vector.translation = (0.5, 0.5, 0.0)
-        node_vector.scale = (0.5, 0.5, 1.0)
+        if bpy.app.version < (2, 81, 0):
+            node_vector.translation = (0.5, 0.5, 0.0)
+            node_vector.scale = (0.5, 0.5, 1.0)
+        else:
+            node_vector.inputs['Location'].default_value = (0.5, 0.5, 0.0)
+            node_vector.inputs['Scale'].default_value = (0.5, 0.5, 1.0)
 
         links.new(tex_coord.outputs['Normal'], vec_trans.inputs['Vector'])
         links.new(vec_trans.outputs['Vector'], node_vector.inputs['Vector'])


### PR DESCRIPTION
Update to work with blender 2.81 (sub 12).

ref.
[Fix node_shader_utils problems with new mapping node](https://developer.blender.org/rB87d0033ea9feb4ff85ef1249ae3b57aaa3c3d540)
[Shading: Rewrite Mapping node with dynamic inputs](https://developer.blender.org/rBbaaa89a0bc54a659f9ddbc34cce21d6920c0f6a6)

