### PR TITLE
Add bone symmetry tool

### DIFF
--- a/mmd_tools/panels/util_tools.py
+++ b/mmd_tools/panels/util_tools.py
@@ -338,3 +338,19 @@ class MMDBoneOrder(_PanelBase, Panel):
                 row.operator('object.vertex_group_move', text='', icon='TRIA_UP').direction = 'UP'
                 row.operator('object.vertex_group_move', text='', icon='TRIA_DOWN').direction = 'DOWN'
 
+
+@register_wrap
+class MMDBoneSymmetryTool(_PanelBase, Panel):
+    bl_idname = 'OBJECT_PT_mmd_tools_bone_symmetry_tool'
+    bl_label = 'Bone Symmetry Tool'
+    bl_context = ''
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        
+        col = layout.column(align=True)
+        col.label(text='Symmetrize .L or .R bones.', icon='BONE_DATA')
+        row = col.row(align=True)
+        row.operator('mmd_tools.symmetrize_bones', text='Left to Right').s_type='L_R'
+        row.operator('mmd_tools.symmetrize_bones', text='Right to Left').s_type='R_L'


### PR DESCRIPTION
I try to symmetrize bones' position using blender's symmetrize tool but it will also overrides mmd bones' name and id,  and this cause the exported pmx file has duplicate bone names.  this Bone Symmetry Tool will simply mirror transform properties for bones with '.L' or '.R' postfix.

Features:
* Mirror Left bones' position to Right bones with the same basename
* Mirror Right bones' position to Left bones with the same basename