### PR TITLE
Avoid AssertionError when using Library Overrides

### DIFF
--- a/mmd_tools/properties/camera.py
+++ b/mmd_tools/properties/camera.py
@@ -30,8 +30,14 @@ else:
                 return view_layer.depsgraph
         return None
 
+def _is_mmd_camera(obj):
+    if obj.type == 'CAMERA':
+        obj = obj.parent
+    return obj and obj.type == 'EMPTY' and obj.mmd_type == 'CAMERA'
 
 def _getMMDCameraAngle(prop):
+    if not _is_mmd_camera(prop.id_data):
+        return 0
     cam = __get_camera(prop.id_data)
     return math.atan(cam.data.sensor_height/cam.data.lens/2) * 2
 
@@ -40,6 +46,8 @@ def _setMMDCameraAngle(prop, value):
     cam.data.lens = cam.data.sensor_height/math.tan(value/2)/2
 
 def _getIsPerspective(prop):
+    if not _is_mmd_camera(prop.id_data):
+        return False
     cam = __get_camera(prop.id_data)
     return cam.data.type == 'PERSP'
 

--- a/mmd_tools/properties/rigid_body.py
+++ b/mmd_tools/properties/rigid_body.py
@@ -70,6 +70,8 @@ def _set_bone(prop, value):
 
 
 def _get_size(prop):
+    if prop.id_data.mmd_type != 'RIGID_BODY':
+        return (0, 0, 0)
     return getRigidBodySize(prop.id_data)
 
 def _set_size(prop, value):

--- a/mmd_tools/properties/root.py
+++ b/mmd_tools/properties/root.py
@@ -162,6 +162,8 @@ def _setVisibilityOfMMDRigArmature(prop, v):
     arm.hide = not v
 
 def _getVisibilityOfMMDRigArmature(prop):
+    if prop.id_data.mmd_type != 'ROOT':
+        return False
     rig = mmd_model.Model(prop.id_data)
     arm = rig.armature()
     return not (arm is None or arm.hide)


### PR DESCRIPTION
When I use Library Overrides, I get a lot of `ValueError` and `AssertionError` error messages in the console.
This happens even when the project file does not contain any MMD models.

The reason for the problem seems to be that Blender is trying to access each custom property without using the panel's `poll` function. The error occurs in the handler function of the property `get`.

This PR changes to validate `prop.id_data` in the `get` handler functions which causes the problem.

#### Steps for reproduce the error (2.91, 2.92)

Creating a library file.

1. Create a new project
2. Add a Cube
3. Save to `library_override_test.blend`

Linking a library and library override.

1. Create a new project
2. `File > Link > library_override_test.blend > Object > Cube`
3. Right-click the Cube on the Outliner and run `ID Data > Add Library Override`.
4. Select the Cube on the Outliner and deselect it repeatedly

```
Traceback (most recent call last):
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/root.py", line 165, in _getVisibilityOfMMDRigArmature
    rig = mmd_model.Model(prop.id_data)
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/core/model.py", line 55, in __init__
    raise ValueError('must be MMD ROOT type object')
ValueError: must be MMD ROOT type object
File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/root.py", line 164, in _getVisibilityOfMMDRigArmature
Traceback (most recent call last):
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/root.py", line 165, in _getVisibilityOfMMDRigArmature
    rig = mmd_model.Model(prop.id_data)
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/core/model.py", line 55, in __init__
    raise ValueError('must be MMD ROOT type object')
ValueError: must be MMD ROOT type object
File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/root.py", line 164, in _getVisibilityOfMMDRigArmature
Traceback (most recent call last):
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 35, in _getMMDCameraAngle
    cam = __get_camera(prop.id_data)
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 18, in __get_camera
    cam = mmd_camera.MMDCamera(empty).camera()
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/core/camera.py", line 15, in __init__
    raise ValueError('%s is not MMDCamera'%str(obj))
ValueError: <bpy_struct, Object("Cube") at 0x7feb3e1b8e08> is not MMDCamera
File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 34, in _getMMDCameraAngle
Traceback (most recent call last):
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 35, in _getMMDCameraAngle
    cam = __get_camera(prop.id_data)
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 18, in __get_camera
    cam = mmd_camera.MMDCamera(empty).camera()
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/core/camera.py", line 15, in __init__
    raise ValueError('%s is not MMDCamera'%str(obj))
ValueError: <bpy_struct, Object("Cube") at 0x7feb3c31c208> is not MMDCamera
File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 34, in _getMMDCameraAngle
Traceback (most recent call last):
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 43, in _getIsPerspective
    cam = __get_camera(prop.id_data)
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 18, in __get_camera
    cam = mmd_camera.MMDCamera(empty).camera()
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/core/camera.py", line 15, in __init__
    raise ValueError('%s is not MMDCamera'%str(obj))
ValueError: <bpy_struct, Object("Cube") at 0x7feb3e1b8e08> is not MMDCamera
File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 42, in _getIsPerspective
Traceback (most recent call last):
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 43, in _getIsPerspective
    cam = __get_camera(prop.id_data)
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 18, in __get_camera
    cam = mmd_camera.MMDCamera(empty).camera()
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/core/camera.py", line 15, in __init__
    raise ValueError('%s is not MMDCamera'%str(obj))
ValueError: <bpy_struct, Object("Cube") at 0x7feb3c31c208> is not MMDCamera
File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/camera.py", line 42, in _getIsPerspective
Traceback (most recent call last):
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/rigid_body.py", line 73, in _get_size
    return getRigidBodySize(prop.id_data)
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/core/model.py", line 28, in getRigidBodySize
    assert(obj.mmd_type == 'RIGID_BODY')
AssertionError
File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/rigid_body.py", line 72, in _get_size
Traceback (most recent call last):
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/rigid_body.py", line 73, in _get_size
    return getRigidBodySize(prop.id_data)
  File "~/.config/blender/2.92/scripts/addons/mmd_tools/core/model.py", line 28, in getRigidBodySize
    assert(obj.mmd_type == 'RIGID_BODY')
AssertionError
File "~/.config/blender/2.92/scripts/addons/mmd_tools/properties/rigid_body.py", line 72, in _get_size
```
