### PR TITLE
Update for property definition type changes of Blender 2.93

### DIFF
--- a/mmd_tools/__init__.py
+++ b/mmd_tools/__init__.py
@@ -18,7 +18,11 @@ def register_wrap(cls):
     #print('%3d'%len(__bl_classes), cls)
     #assert(cls not in __bl_classes)
     if __make_annotations:
-        bl_props = {k:v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+        import bpy
+        if bpy.app.version >= (2, 93, 0):
+            bl_props = {k:v for k, v in cls.__dict__.items() if isinstance(v, bpy.props._PropertyDeferred)}
+        else:
+            bl_props = {k:v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
         if bl_props:
             if '__annotations__' not in cls.__dict__:
                 setattr(cls, '__annotations__', {})


### PR DESCRIPTION
Support for Blender 2.93 beta and 3.0 alpha.
This change may change in the future, but it works with current 2.93 beta.
Tested with 2.83, 2.92, 2.93 beta, 3.0 alpha.

ref.
[PyAPI: expose unstable type bpy.props._PropertyDeferred](https://developer.blender.org/rBc44c611c6d8c6ae071b48efb5fc07168f18cd17e)
[Dynamic PropertyGroup classes no longer possible in 2.93](https://developer.blender.org/T86719)