### PR TITLE
Support for changing Rigid Body World default settings in 2.92

### DIFF
--- a/mmd_tools/operators/rigid_body.py
+++ b/mmd_tools/operators/rigid_body.py
@@ -467,10 +467,8 @@ class UpdateRigidBodyWorld(Operator):
             rbw.constraints = bpy.data.collections.new('RigidBodyConstraints')
             rbw.constraints.use_fake_user = True
 
-        if bpy.app.version >= (2, 92, 0):
-            # see: https://github.com/powroupi/blender_mmd_tools/issues/333
+        if hasattr(bpy.context.scene.rigidbody_world, 'substeps_per_frame'):
             bpy.context.scene.rigidbody_world.substeps_per_frame = 1
-            bpy.context.scene.rigidbody_world.solver_iterations = 60
 
         return rbw.collection.objects, rbw.constraints.objects
 

--- a/mmd_tools/operators/rigid_body.py
+++ b/mmd_tools/operators/rigid_body.py
@@ -466,6 +466,12 @@ class UpdateRigidBodyWorld(Operator):
         if not rbw.constraints:
             rbw.constraints = bpy.data.collections.new('RigidBodyConstraints')
             rbw.constraints.use_fake_user = True
+
+        if bpy.app.version >= (2, 92, 0):
+            # see: https://github.com/powroupi/blender_mmd_tools/issues/333
+            bpy.context.scene.rigidbody_world.substeps_per_frame = 1
+            bpy.context.scene.rigidbody_world.solver_iterations = 60
+
         return rbw.collection.objects, rbw.constraints.objects
 
     def execute(self, context):


### PR DESCRIPTION
@nagadomi pointed out the problem in #333

I don't know what value to set.
In my scene, the following values were good.
```python
bpy.context.scene.rigidbody_world.substeps_per_frame = 1
bpy.context.scene.rigidbody_world.solver_iterations = 60
```